### PR TITLE
feat: persist downSource with localStorage; add width for models-table operation-column

### DIFF
--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+	semi: true,
+	singleQuote: true,
+}

--- a/renderer/hooks/useLocalStorageState.tsx
+++ b/renderer/hooks/useLocalStorageState.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from 'react'
+
+
+export default function useLocalStorageState<T extends string | number | boolean | object>(
+  key: string,
+  defaultValue: (() => T) | T,
+  validate: (value: unknown) => boolean = () => true
+) {
+  const [value, setValue] = useState<T>(defaultValue)
+	const inited = useRef(false)
+
+  useEffect(() => {
+		const init =  () => {
+			inited.current = true
+		}
+
+    if (typeof window === 'undefined') return init()
+
+    const str = localStorage.getItem(key)
+    if (!str) return init()
+
+    let val: any
+    try {
+      val = JSON.parse(str)
+    } catch {
+      localStorage.removeItem(key)
+      return init()
+    }
+
+    if (validate(val)) {
+      setValue(val)
+    } else {
+      localStorage.removeItem(key)
+    }
+		init()
+  }, [key])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && inited.current) {
+      localStorage.setItem(key, JSON.stringify(value))
+    }
+  }, [key, value])
+
+  return [value, setValue] as const
+}

--- a/renderer/hooks/useLocalStorageState.tsx
+++ b/renderer/hooks/useLocalStorageState.tsx
@@ -1,45 +1,46 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react';
 
-
-export default function useLocalStorageState<T extends string | number | boolean | object>(
+export default function useLocalStorageState<
+  T extends string | number | boolean | object,
+>(
   key: string,
   defaultValue: (() => T) | T,
-  validate: (value: unknown) => boolean = () => true
+  validate: (value: unknown) => boolean = () => true,
 ) {
-  const [value, setValue] = useState<T>(defaultValue)
-	const inited = useRef(false)
+  const [value, setValue] = useState<T>(defaultValue);
+  const inited = useRef(false);
 
   useEffect(() => {
-		const init =  () => {
-			inited.current = true
-		}
+    const init = () => {
+      inited.current = true;
+    };
 
-    if (typeof window === 'undefined') return init()
+    if (typeof window === 'undefined') return init();
 
-    const str = localStorage.getItem(key)
-    if (!str) return init()
+    const str = localStorage.getItem(key);
+    if (!str) return init();
 
-    let val: any
+    let val: any;
     try {
-      val = JSON.parse(str)
+      val = JSON.parse(str);
     } catch {
-      localStorage.removeItem(key)
-      return init()
+      localStorage.removeItem(key);
+      return init();
     }
 
     if (validate(val)) {
-      setValue(val)
+      setValue(val);
     } else {
-      localStorage.removeItem(key)
+      localStorage.removeItem(key);
     }
-		init()
-  }, [key])
+    init();
+  }, [key]);
 
   useEffect(() => {
     if (typeof window !== 'undefined' && inited.current) {
-      localStorage.setItem(key, JSON.stringify(value))
+      localStorage.setItem(key, JSON.stringify(value));
     }
-  }, [key, value])
+  }, [key, value]);
 
-  return [value, setValue] as const
+  return [value, setValue] as const;
 }

--- a/renderer/pages/[locale]/modelsControl.tsx
+++ b/renderer/pages/[locale]/modelsControl.tsx
@@ -21,10 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  getModelDownloadUrl,
-  models,
-} from 'lib/utils';
+import { getModelDownloadUrl, models } from 'lib/utils';
 import { Button } from '@/components/ui/button';
 import { ISystemInfo } from '../../types';
 import DeleteModel from '@/components/DeleteModel';
@@ -44,7 +41,7 @@ import useLocalStorageState from 'hooks/useLocalStorageState';
 
 export enum DownSource {
   HuggingFace = 'huggingface',
-  HfMirror = 'hf-mirror'
+  HfMirror = 'hf-mirror',
 }
 
 const ModelsControl = () => {
@@ -55,10 +52,10 @@ const ModelsControl = () => {
     modelsPath: '',
   });
   const [downSource, setDownSource] = useLocalStorageState<DownSource>(
-		'downSource',
-		DownSource.HuggingFace,
-		val => Object.values(DownSource).includes(val as DownSource)
-	);
+    'downSource',
+    DownSource.HuggingFace,
+    (val) => Object.values(DownSource).includes(val as DownSource),
+  );
 
   useEffect(() => {
     updateSystemInfo();
@@ -140,7 +137,7 @@ const ModelsControl = () => {
               <TableHead className="w-[230px]">{t('modelName')}</TableHead>
               <TableHead>{t('downloadLink')}</TableHead>
               <TableHead>{t('size')}</TableHead>
-              <TableHead className='w-[150px]'>{t('operation')}</TableHead>
+              <TableHead className="w-[150px]">{t('operation')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody className="max-h-[80vh]">
@@ -153,7 +150,7 @@ const ModelsControl = () => {
                       <span className="mr-2 text-sm">
                         {getModelDownloadUrl(
                           model.name,
-                          source as 'hf-mirror' | 'huggingface'
+                          source as 'hf-mirror' | 'huggingface',
                         )}
                       </span>
                       <TooltipProvider>
@@ -165,8 +162,8 @@ const ModelsControl = () => {
                                 copyToClipboard(
                                   getModelDownloadUrl(
                                     model.name,
-                                    source as 'hf-mirror' | 'huggingface'
-                                  )
+                                    source as 'hf-mirror' | 'huggingface',
+                                  ),
                                 )
                               }
                             />

--- a/renderer/pages/[locale]/modelsControl.tsx
+++ b/renderer/pages/[locale]/modelsControl.tsx
@@ -40,6 +40,12 @@ import {
 import { toast } from 'sonner';
 import { useTranslation } from 'next-i18next';
 import { getStaticPaths, makeStaticProperties } from '../../lib/get-static';
+import useLocalStorageState from 'hooks/useLocalStorageState';
+
+export enum DownSource {
+  HuggingFace = 'huggingface',
+  HfMirror = 'hf-mirror'
+}
 
 const ModelsControl = () => {
   const { t } = useTranslation('modelsControl');
@@ -48,7 +54,11 @@ const ModelsControl = () => {
     downloadingModels: [],
     modelsPath: '',
   });
-  const [downSource, setDownSource] = useState('huggingface');
+  const [downSource, setDownSource] = useLocalStorageState<DownSource>(
+		'downSource',
+		DownSource.HuggingFace,
+		val => Object.values(DownSource).includes(val as DownSource)
+	);
 
   useEffect(() => {
     updateSystemInfo();
@@ -63,7 +73,7 @@ const ModelsControl = () => {
     systemInfo?.modelsInstalled?.includes(name.toLowerCase());
 
   const handleDownSource = (value: string) => {
-    setDownSource(value);
+    setDownSource(value as DownSource);
   };
 
   const handleImportModel = async () => {
@@ -107,7 +117,7 @@ const ModelsControl = () => {
           <span className="float-right mt-4 flex items-center">
             <span>{t('switchDownloadSource')}:</span>
             <Select onValueChange={handleDownSource} value={downSource}>
-              <SelectTrigger className="w-[250px]">
+              <SelectTrigger className="w-[250px] ml-2">
                 <SelectValue placeholder={t('switchDownloadSource')} />
               </SelectTrigger>
               <SelectContent>
@@ -130,7 +140,7 @@ const ModelsControl = () => {
               <TableHead className="w-[230px]">{t('modelName')}</TableHead>
               <TableHead>{t('downloadLink')}</TableHead>
               <TableHead>{t('size')}</TableHead>
-              <TableHead>{t('operation')}</TableHead>
+              <TableHead className='w-[150px]'>{t('operation')}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody className="max-h-[80vh]">


### PR DESCRIPTION
1. 记住 models 下载源
2. 设置 models 下载表格-操作列 的宽度, 防止下载 progress 更新时, 表格宽度抖动

![smart-sub-down-model-shaking](https://github.com/user-attachments/assets/430f6a42-3501-4315-89c5-5a716cc4aa27)
