### PR TITLE
fix(style): fix form label text/tooltip-icon vertical align

### DIFF
--- a/renderer/components/TaskConfigForm.tsx
+++ b/renderer/components/TaskConfigForm.tsx
@@ -198,7 +198,7 @@ const TaskConfigForm = ({ form, formData, systemInfo }) => {
                     name="prompt"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>
+                        <FormLabel className='flex items-center'>
                           {t('prompt')} <ToolTips text={t('promptTips')} />
                         </FormLabel>
                         <FormControl>
@@ -218,7 +218,7 @@ const TaskConfigForm = ({ form, formData, systemInfo }) => {
                     name="maxContext"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>
+                        <FormLabel className='flex items-center'>
                           {t('maxContext')}
                           <ToolTips text={t('maxContextTip')} />
                         </FormLabel>
@@ -250,7 +250,7 @@ const TaskConfigForm = ({ form, formData, systemInfo }) => {
                     name="sourceSrtSaveOption"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>
+                        <FormLabel className='flex items-center'>
                           {t('sourceSubtitleSaveSettings')}
                           <SavePathNotice />
                         </FormLabel>


### PR DESCRIPTION
before
![image](https://github.com/user-attachments/assets/6c148c9f-b45a-4233-9366-e995289de0ff)


after
![image](https://github.com/user-attachments/assets/5a0634ec-a6af-4bdf-bc49-d411748d8340)
