### PR TITLE
fix(style): unify sidebar iconSize; fix dark-mode border-color

### DIFF
--- a/renderer/components/Layout.tsx
+++ b/renderer/components/Layout.tsx
@@ -128,7 +128,7 @@ const Layout = ({ children }) => {
                   onClick={() =>
                     openUrl('https://github.com/buxuku/SmartSub')
                   }
-                  className="inline-block cursor-pointer"
+                  className="size-5 inline-block cursor-pointer"
                 />
               </TooltipTrigger>
               <TooltipContent side="right" sideOffset={5}>

--- a/renderer/tailwind.config.js
+++ b/renderer/tailwind.config.js
@@ -50,6 +50,9 @@ module.exports = {
                     foreground: "hsl(var(--card-foreground))",
                 },
             },
+						borderColor: {
+								DEFAULT: "hsl(var(--border))",
+						},
             borderRadius: {
                 lg: "var(--radius)",
                 md: "calc(var(--radius) - 2px)",

--- a/renderer/tailwind.config.js
+++ b/renderer/tailwind.config.js
@@ -1,81 +1,81 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-    darkMode: ["class"],
-    content: [
-        './renderer/pages/**/*.{js,ts,jsx,tsx}',
-        './renderer/components/**/*.{js,ts,jsx,tsx}',
-    ],
-    prefix: "",
-    theme: {
-        container: {
-            center: true,
-            padding: "2rem",
-            screens: {
-                "2xl": "1400px",
-            },
-        },
-        extend: {
-            colors: {
-                border: "hsl(var(--border))",
-                input: "hsl(var(--input))",
-                ring: "hsl(var(--ring))",
-                background: "hsl(var(--background))",
-                foreground: "hsl(var(--foreground))",
-                primary: {
-                    DEFAULT: "hsl(var(--primary))",
-                    foreground: "hsl(var(--primary-foreground))",
-                },
-                secondary: {
-                    DEFAULT: "hsl(var(--secondary))",
-                    foreground: "hsl(var(--secondary-foreground))",
-                },
-                destructive: {
-                    DEFAULT: "hsl(var(--destructive))",
-                    foreground: "hsl(var(--destructive-foreground))",
-                },
-                muted: {
-                    DEFAULT: "hsl(var(--muted))",
-                    foreground: "hsl(var(--muted-foreground))",
-                },
-                accent: {
-                    DEFAULT: "hsl(var(--accent))",
-                    foreground: "hsl(var(--accent-foreground))",
-                },
-                popover: {
-                    DEFAULT: "hsl(var(--popover))",
-                    foreground: "hsl(var(--popover-foreground))",
-                },
-                card: {
-                    DEFAULT: "hsl(var(--card))",
-                    foreground: "hsl(var(--card-foreground))",
-                },
-            },
-						borderColor: {
-								DEFAULT: "hsl(var(--border))",
-						},
-            borderRadius: {
-                lg: "var(--radius)",
-                md: "calc(var(--radius) - 2px)",
-                sm: "calc(var(--radius) - 4px)",
-            },
-            keyframes: {
-                "accordion-down": {
-                    from: { height: "0" },
-                    to: { height: "var(--radix-accordion-content-height)" },
-                },
-                "accordion-up": {
-                    from: { height: "var(--radix-accordion-content-height)" },
-                    to: { height: "0" },
-                },
-            },
-            animation: {
-                "accordion-down": "accordion-down 0.2s ease-out",
-                "accordion-up": "accordion-up 0.2s ease-out",
-            },
-            gridTemplateColumns: {
-                'auto-min': 'auto min-content',
-            },
-        },
+  darkMode: ['class'],
+  content: [
+    './renderer/pages/**/*.{js,ts,jsx,tsx}',
+    './renderer/components/**/*.{js,ts,jsx,tsx}',
+  ],
+  prefix: '',
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
     },
-    plugins: [require("tailwindcss-animate")],
-}
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderColor: {
+        DEFAULT: 'hsl(var(--border))',
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+      gridTemplateColumns: {
+        'auto-min': 'auto min-content',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
+};


### PR DESCRIPTION
- github 链接图标统一尺寸 `size-5`
- fix dark mode border, 根据 [tailwind v3 文档](https://v3.tailwindcss.com/docs/preflight#border-styles-are-reset-globally) 需要从 `theme('borderColor.DEFAULT', currentColor)` 定制 


![image](https://github.com/user-attachments/assets/5d11b30c-23ea-47ec-ae6e-3357003a552c)
