### PR TITLE
fix: 拆分字幕弹窗内容过长时可滚动，确认按钮始终可见

### DIFF
--- a/renderer/components/subtitle/SubtitleEditToolbar.tsx
+++ b/renderer/components/subtitle/SubtitleEditToolbar.tsx
@@ -707,25 +707,28 @@ Only respond with the translated/improved text, nothing else.`;
           <Scissors className="h-4 w-4 mr-1" />
           {t('split') || '拆分'}
         </Button>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-lg flex flex-col">
           <DialogHeader>
             <DialogTitle>{t('splitSubtitle') || '拆分字幕'}</DialogTitle>
             <DialogDescription>
               {t('splitSubtitleDesc') || '选择文字拆分位置和时间分配'}
             </DialogDescription>
           </DialogHeader>
-          {currentSubtitleIndex >= 0 &&
-            currentSubtitleIndex < subtitles.length && (
-              <SplitPreview
-                subtitle={subtitles[currentSubtitleIndex]}
-                splitPosition={splitPosition}
-                setSplitPosition={setSplitPosition}
-                splitTimePercent={splitTimePercent}
-                setSplitTimePercent={setSplitTimePercent}
-                shouldShowTranslation={shouldShowTranslation}
-                t={t}
-              />
-            )}
+          {/* 长字幕时预览区可滚动，确保底部的确认按钮始终可见 */}
+          <div className="flex-1 min-h-0 overflow-y-auto">
+            {currentSubtitleIndex >= 0 &&
+              currentSubtitleIndex < subtitles.length && (
+                <SplitPreview
+                  subtitle={subtitles[currentSubtitleIndex]}
+                  splitPosition={splitPosition}
+                  setSplitPosition={setSplitPosition}
+                  splitTimePercent={splitTimePercent}
+                  setSplitTimePercent={setSplitTimePercent}
+                  shouldShowTranslation={shouldShowTranslation}
+                  t={t}
+                />
+              )}
+          </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowSplit(false)}>
               {t('cancel') || '取消'}


### PR DESCRIPTION
修复 #311：翻译后编辑时，若单段文字过长，拆分弹窗内容会超出视口高度，
而 DialogContent 基类为 max-h-[90vh] + overflow-hidden，导致底部被裁剪、 无滚动条、滚轮无效，确认按钮被挡住无法点击。

改为 flex 纵向布局：标题与底部按钮固定，中间预览区 overflow-y-auto 滚动，
确保"确认拆分"按钮在任何文字长度下都可见可点。
（同文件的 AI 优化弹窗此前已用 overflow-y-auto 处理，拆分弹窗遗漏了该处理。）