### PR TITLE
fix: derive ffmpeg progress from timemark when percent is unavailable

### DIFF
--- a/main/helpers/audioProcessor.ts
+++ b/main/helpers/audioProcessor.ts
@@ -3,7 +3,7 @@ import ffmpeg from 'fluent-ffmpeg';
 import path from 'path';
 import fs from 'fs';
 import { logMessage } from './storeManager';
-import { getMd5, ensureTempDir } from './fileUtils';
+import { getMd5, ensureTempDir, timemarkToSeconds } from './fileUtils';
 
 // 设置ffmpeg路径
 const ffmpegPath = ffmpegStatic.replace('app.asar', 'app.asar.unpacked');
@@ -19,12 +19,21 @@ export const extractAudio = (
   file = null,
 ) => {
   const onProgress = (percent = 0) => {
-    logMessage(`extract audio progress ${percent}%`, 'info');
+    const safePercent = Math.min(Math.max(Math.round(percent), 0), 100);
+    logMessage(`extract audio progress ${safePercent}%`, 'info');
     if (event && file) {
-      event.sender.send('taskProgressChange', file, 'extractAudio', percent);
+      event.sender.send(
+        'taskProgressChange',
+        file,
+        'extractAudio',
+        safePercent,
+      );
     }
   };
   return new Promise((resolve, reject) => {
+    // fluent-ffmpeg 的 progress.percent 在部分平台/新版 ffmpeg 上恒为 undefined，
+    // 这里从 codecData 拿到媒体总时长，再用 progress.timemark 自算百分比（issue #291）。
+    let totalDurationSec = 0;
     try {
       ffmpeg(`${videoPath}`)
         .audioFrequency(16000)
@@ -35,9 +44,23 @@ export const extractAudio = (
           onProgress(0);
           logMessage(`extract audio start ${str}`, 'info');
         })
+        .on('codecData', function (data) {
+          totalDurationSec = timemarkToSeconds(data?.duration);
+        })
         .on('progress', function (progress) {
-          const percent = progress.percent || 0;
-          onProgress(percent);
+          let percent = progress.percent;
+          if (
+            (percent === undefined ||
+              percent === null ||
+              Number.isNaN(percent) ||
+              percent <= 0) &&
+            totalDurationSec > 0 &&
+            progress.timemark
+          ) {
+            percent =
+              (timemarkToSeconds(progress.timemark) / totalDurationSec) * 100;
+          }
+          onProgress(percent || 0);
         })
         .on('end', function (str) {
           logMessage(`extract audio done!`, 'info');

--- a/main/helpers/fileUtils.ts
+++ b/main/helpers/fileUtils.ts
@@ -12,6 +12,21 @@ export function getMd5(str: string) {
 }
 
 /**
+ * 将 ffmpeg 的时间标记（HH:MM:SS.xx / MM:SS / 纯秒数）转换为秒。
+ * 用于在 fluent-ffmpeg 的 progress.percent 不可用时，根据 timemark 与总时长自算进度。
+ */
+export function timemarkToSeconds(timemark: string | number): number {
+  if (typeof timemark === 'number')
+    return Number.isFinite(timemark) ? timemark : 0;
+  if (!timemark) return 0;
+  const parts = timemark.split(':').map((p) => parseFloat(p));
+  if (parts.some((n) => Number.isNaN(n))) return 0;
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  if (parts.length === 2) return parts[0] * 60 + parts[1];
+  return parts[0] || 0;
+}
+
+/**
  * 获取临时目录路径
  */
 export function getTempDir() {

--- a/main/helpers/subtitleMerger.ts
+++ b/main/helpers/subtitleMerger.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { logMessage } from './storeManager';
+import { timemarkToSeconds } from './fileUtils';
 import type {
   SubtitleStyle,
   MergeConfig,
@@ -232,11 +233,14 @@ export async function mergeSubtitleToVideo(
   // 获取视频分辨率，用于显式设置 original_size
   // 防止滤镜重新初始化时因自动检测失败而报错
   let originalSize = '';
+  // 视频总时长（秒），用于在 progress.percent 不可用时自算合并进度（issue #310）
+  let totalDurationSec = 0;
   try {
     const videoInfo = await getVideoInfo(videoPath);
     if (videoInfo.width > 0 && videoInfo.height > 0) {
       originalSize = `:original_size=${videoInfo.width}x${videoInfo.height}`;
     }
+    totalDurationSec = videoInfo.duration || 0;
   } catch (err) {
     logMessage(
       `获取视频分辨率失败，跳过 original_size 设置: ${err}`,
@@ -286,7 +290,19 @@ export async function mergeSubtitleToVideo(
         logMessage(`FFmpeg 命令: ${cmd}`, 'info');
       })
       .on('progress', (progress) => {
-        const percent = progress.percent || 0;
+        let percent = progress.percent;
+        if (
+          (percent === undefined ||
+            percent === null ||
+            Number.isNaN(percent) ||
+            percent <= 0) &&
+          totalDurationSec > 0 &&
+          progress.timemark
+        ) {
+          percent =
+            (timemarkToSeconds(progress.timemark) / totalDurationSec) * 100;
+        }
+        percent = Math.max(percent || 0, 0);
         logMessage(`合并进度: ${percent.toFixed(1)}%`, 'info');
         onProgress?.({
           percent: Math.min(percent, 99),


### PR DESCRIPTION
fluent-ffmpeg's progress.percent is undefined on some platforms and newer ffmpeg builds, so audio extraction progress stayed at 0% until jumping to 100% (#291), and subtitle merge showed no percentage at all (#310).

Capture the total media duration (audio extract: codecData event; merge: ffprobe) and compute the percentage from progress.timemark as a fallback when percent is missing. Add a shared timemarkToSeconds helper.

Refs #291, #310