### PR TITLE
fix: add request timeout to translation providers to prevent stuck pr…

### DIFF
--- a/main/service/aliyun.ts
+++ b/main/service/aliyun.ts
@@ -2,6 +2,7 @@ import { convertLanguageCode } from '../helpers/utils';
 import alimt20181012 from '@alicloud/alimt20181012';
 import * as $OpenApi from '@alicloud/openapi-client';
 import * as $Util from '@alicloud/tea-util';
+import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
 
 // 客户端实例
 let client: any = null;
@@ -18,17 +19,23 @@ export default async function translate(
   query: string | string[],
   proof: { apiKey: string; apiSecret: string; endpoint?: string },
   sourceLanguage: string,
-  targetLanguage: string
+  targetLanguage: string,
 ) {
-  const { apiKey: accessKeyId, apiSecret: accessKeySecret, endpoint = 'mt.aliyuncs.com' } = proof || {};
+  const {
+    apiKey: accessKeyId,
+    apiSecret: accessKeySecret,
+    endpoint = 'mt.aliyuncs.com',
+  } = proof || {};
   if (!accessKeyId || !accessKeySecret) {
     console.log('请先配置阿里云 AccessKey ID 和 AccessKey Secret');
     throw new Error('missingKeyOrSecret');
   }
 
   // 语言代码转换
-  const formatSourceLanguage = convertLanguageCode(sourceLanguage, 'aliyun') || sourceLanguage;
-  const formatTargetLanguage = convertLanguageCode(targetLanguage, 'aliyun') || targetLanguage;
+  const formatSourceLanguage =
+    convertLanguageCode(sourceLanguage, 'aliyun') || sourceLanguage;
+  const formatTargetLanguage =
+    convertLanguageCode(targetLanguage, 'aliyun') || targetLanguage;
 
   if (!formatSourceLanguage || !formatTargetLanguage) {
     console.log('不支持的语言');
@@ -46,12 +53,22 @@ export default async function translate(
       if (query.length === 0) {
         return [];
       }
-      
+
       // 批量翻译处理
-      return await batchTranslate(client, query, formatSourceLanguage, formatTargetLanguage);
+      return await batchTranslate(
+        client,
+        query,
+        formatSourceLanguage,
+        formatTargetLanguage,
+      );
     } else {
       // 单文本翻译，包装成批量处理
-      const results = await batchTranslate(client, [query], formatSourceLanguage, formatTargetLanguage);
+      const results = await batchTranslate(
+        client,
+        [query],
+        formatSourceLanguage,
+        formatTargetLanguage,
+      );
       return results[0];
     }
   } catch (error) {
@@ -63,7 +80,11 @@ export default async function translate(
 /**
  * 创建阿里云翻译客户端
  */
-function createClient(accessKeyId: string, accessKeySecret: string, endpoint: string): any {
+function createClient(
+  accessKeyId: string,
+  accessKeySecret: string,
+  endpoint: string,
+): any {
   const config = new $OpenApi.Config({
     accessKeyId,
     accessKeySecret,
@@ -81,7 +102,7 @@ async function batchTranslate(
   client: any,
   texts: string[],
   sourceLanguage: string,
-  targetLanguage: string
+  targetLanguage: string,
 ): Promise<string[]> {
   // 准备批量翻译的输入格式
   // 格式: { "1": "text1", "2": "text2", ... }
@@ -100,16 +121,22 @@ async function batchTranslate(
     targetLanguage: targetLanguage,
     scene: 'general',
     apiType: 'translate_standard', // 使用通用版翻译服务
-    sourceText: sourceTextJson
+    sourceText: sourceTextJson,
   };
 
-  // 运行时选项
-  const runtime = new $Util.RuntimeOptions({});
-  
+  // 运行时选项：设置读写超时，避免请求无限挂起导致翻译流程卡死（issue #269）
+  const runtime = new $Util.RuntimeOptions({
+    readTimeout: TRANSLATION_REQUEST_TIMEOUT,
+    connectTimeout: TRANSLATION_REQUEST_TIMEOUT,
+  });
+
   try {
     // 发起批量翻译请求
-    const response = await client.getBatchTranslateWithOptions(request, runtime);
-    
+    const response = await client.getBatchTranslateWithOptions(
+      request,
+      runtime,
+    );
+
     // 处理返回结果
     if (response?.body?.code === 200 && response?.body?.translatedList) {
       // 构建结果数组，保持原始顺序
@@ -119,14 +146,14 @@ async function batchTranslate(
           resultMap[item.index] = item.translated;
         }
       }
-      
+
       // 按原始顺序返回结果
       return texts.map((_, index) => resultMap[`${index}`] || '');
     }
-    
+
     throw new Error(response?.body?.message || '批量翻译请求返回错误');
   } catch (error) {
     console.error('阿里云批量翻译错误:', error);
     throw error;
   }
-} 
+}

--- a/main/service/azure.ts
+++ b/main/service/azure.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
 
 interface AzureTranslateResponse {
   translations: {
@@ -49,6 +50,7 @@ const azureTranslator = async (
       params: params,
       data: requestBody,
       responseType: 'json',
+      timeout: TRANSLATION_REQUEST_TIMEOUT,
     });
     console.log(response, 'response');
 

--- a/main/service/baidu.ts
+++ b/main/service/baidu.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
+import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
 
 export default async function baidu(
   query,
@@ -41,6 +42,7 @@ export default async function baidu(
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
+      timeout: TRANSLATION_REQUEST_TIMEOUT,
     },
   );
   if (!res?.data?.trans_result) {

--- a/main/service/deeplx.ts
+++ b/main/service/deeplx.ts
@@ -1,12 +1,17 @@
 import axios from 'axios';
+import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
 export default async function deeplx(query, proof) {
   const { apiUrl } = proof || {};
   try {
-    const res = await axios.post(apiUrl, {
-      text: query?.join('\n'),
-      source_lang: 'en',
-      target_lang: 'zh',
-    });
+    const res = await axios.post(
+      apiUrl,
+      {
+        text: query?.join('\n'),
+        source_lang: 'en',
+        target_lang: 'zh',
+      },
+      { timeout: TRANSLATION_REQUEST_TIMEOUT },
+    );
     return res?.data?.alternatives?.[0] || '';
   } catch (error) {
     console.log(error, 'error');

--- a/main/service/doubao.ts
+++ b/main/service/doubao.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
+import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
 
 const DOUBAO_API_URL = 'https://ark.cn-beijing.volces.com/api/v3/responses';
 const DEFAULT_MODEL = 'doubao-seed-translation-250915';
@@ -54,6 +55,7 @@ export default async function translate(
           'Content-Type': 'application/json',
           Authorization: `Bearer ${apiKey}`,
         },
+        timeout: TRANSLATION_REQUEST_TIMEOUT,
       });
 
       // 解析响应

--- a/main/service/google.ts
+++ b/main/service/google.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
+import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
 
 export default async function google(
   query,
@@ -43,6 +44,7 @@ export default async function google(
         headers: {
           'Content-Type': 'application/json',
         },
+        timeout: TRANSLATION_REQUEST_TIMEOUT,
       },
     );
 

--- a/main/service/ollama.ts
+++ b/main/service/ollama.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { TRANSLATION_JSON_SCHEMA } from '../translate/constants/schema';
+import { OLLAMA_REQUEST_TIMEOUT } from '../translate/constants';
 
 interface OllamaConfig {
   apiUrl: string;
@@ -25,15 +26,19 @@ export default async function translateWithOllama(
       enhancedSystemPrompt = `${systemPrompt}\n\n你必须以JSON格式返回数据，不要包含任何其他文本或说明。输出应该是一个有效的JSON对象，其中键是字幕ID，值是翻译后的内容。\n\n下面是返回的JSON Schema:\n${JSON.stringify(TRANSLATION_JSON_SCHEMA, null, 2)}`;
     }
 
-    const response = await axios.post(`${url}`, {
-      model: modelName,
-      messages: [
-        { role: 'system', content: enhancedSystemPrompt },
-        { role: 'user', content: text },
-      ],
-      stream: false,
-      format: 'json',
-    });
+    const response = await axios.post(
+      `${url}`,
+      {
+        model: modelName,
+        messages: [
+          { role: 'system', content: enhancedSystemPrompt },
+          { role: 'user', content: text },
+        ],
+        stream: false,
+        format: 'json',
+      },
+      { timeout: OLLAMA_REQUEST_TIMEOUT },
+    );
 
     if (response.data && response.data.message) {
       return response.data.message?.content?.trim();

--- a/main/translate/constants/index.ts
+++ b/main/translate/constants/index.ts
@@ -9,6 +9,12 @@ export const DEFAULT_BATCH_SIZE = {
   API: 1,
 } as const;
 
+// 翻译请求超时时间（毫秒）。
+// 防止单个请求无限挂起导致整个翻译流程卡死、进度永久停留（issue #269）。
+export const TRANSLATION_REQUEST_TIMEOUT = 60_000;
+// 本地大模型（Ollama）响应可能较慢，使用更宽松的超时时间。
+export const OLLAMA_REQUEST_TIMEOUT = 300_000;
+
 export const THINK_TAG_REGEX = /<think>[\s\S]*?<\/think>\n/g;
 export const RESULT_TAG_REGEX = /<result[^>]*>([\s\S]*?)<\/result>/;
 


### PR DESCRIPTION
…ogress

The non-AI translation providers used axios without a timeout (axios defaults to no timeout), so a single stalled request hung the whole translation loop forever. Earlier subtitles were already written incrementally, so the file looked complete while the task stayed in the loading state, showing a stuck percentage such as 67.25% (#269).

Add a 60s timeout to the cloud providers (deeplx, google, baidu, azure, doubao) and aliyun (via RuntimeOptions), and a 300s timeout to ollama for slower local models. openai/volc already have SDK-level timeouts.

Refs #269