### PR TITLE
feat: retry failed tasks

### DIFF
--- a/renderer/components/TaskControls.tsx
+++ b/renderer/components/TaskControls.tsx
@@ -1,18 +1,35 @@
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 import { Button } from './ui/button';
 import { toast } from 'sonner';
-import { isSubtitleFile, needsCoreML, cn } from 'lib/utils';
+import { cn } from 'lib/utils';
 import { useTranslation } from 'next-i18next';
+import { RefreshCw } from 'lucide-react';
+import { IFiles } from '../../types';
+import {
+  getFailedTaskFiles,
+  getRunnableTaskFiles,
+  resetTaskRunState,
+} from '@/lib/taskWorkflow';
 
 interface TaskControlsProps {
-  files: any[];
+  files: IFiles[];
+  setFiles: Dispatch<SetStateAction<IFiles[]>>;
   formData: any;
   className?: string;
 }
 
-const TaskControls = ({ files, formData, className }: TaskControlsProps) => {
+const TaskControls = ({
+  files,
+  setFiles,
+  formData,
+  className,
+}: TaskControlsProps) => {
   const [taskStatus, setTaskStatus] = useState('idle');
   const { t } = useTranslation(['home', 'common']);
+  const failedFiles = useMemo(
+    () => getFailedTaskFiles(files, formData),
+    [files, formData],
+  );
 
   useEffect(() => {
     // 获取当前任务状态
@@ -32,27 +49,28 @@ const TaskControls = ({ files, formData, className }: TaskControlsProps) => {
     };
   }, []);
 
-  const handleTask = async () => {
+  const startTaskWithFiles = (filesToRun: IFiles[]) => {
+    const taskIds = new Set(filesToRun.map((file) => file.uuid));
+    const nextFiles = files.map((file) =>
+      taskIds.has(file.uuid) ? resetTaskRunState(file) : file,
+    );
+    const queuedFiles = nextFiles.filter((file) => taskIds.has(file.uuid));
+
+    setFiles(nextFiles);
+    setTaskStatus('running');
+    window?.ipc?.send('handleTask', { files: queuedFiles, formData });
+  };
+
+  const handleTask = () => {
     if (!files?.length) {
       toast(t('common:notification'), {
         description: t('home:noTask'),
       });
       return;
     }
-    const isAllFilesProcessed = files.every((item) => {
-      const basicProcessingDone = item.extractAudio && item.extractSubtitle;
 
-      if (formData.translateProvider === '-1') {
-        return basicProcessingDone;
-      }
-      if (isSubtitleFile(item?.filePath)) {
-        return item.translateSubtitle;
-      }
-
-      return basicProcessingDone && item.translateSubtitle;
-    });
-
-    if (isAllFilesProcessed) {
+    const runnableFiles = getRunnableTaskFiles(files, formData);
+    if (!runnableFiles.length) {
       toast(t('common:notification'), {
         description: t('home:allFilesProcessed'),
       });
@@ -67,8 +85,20 @@ const TaskControls = ({ files, formData, className }: TaskControlsProps) => {
     //     return;
     //   }
     // }
-    setTaskStatus('running');
-    window?.ipc?.send('handleTask', { files, formData });
+    startTaskWithFiles(runnableFiles);
+  };
+
+  const handleRetryFailed = () => {
+    if (!failedFiles.length) {
+      toast(t('common:notification'), {
+        description: t('home:noFailedTasks', {
+          defaultValue: '没有失败任务需要重试',
+        }),
+      });
+      return;
+    }
+
+    startTaskWithFiles(failedFiles);
   };
   const handlePause = () => {
     window?.ipc?.send('pauseTask', null);
@@ -87,9 +117,24 @@ const TaskControls = ({ files, formData, className }: TaskControlsProps) => {
   return (
     <div className={cn('flex gap-2 ml-auto', className)}>
       {(taskStatus === 'idle' || taskStatus === 'completed') && (
-        <Button onClick={handleTask} disabled={!files.length}>
-          {t('home:startTask')}
-        </Button>
+        <>
+          {failedFiles.length > 0 && (
+            <Button
+              variant="outline"
+              onClick={handleRetryFailed}
+              disabled={!files.length}
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              {t('home:retryFailedTasks', {
+                count: failedFiles.length,
+                defaultValue: `重试失败任务 (${failedFiles.length})`,
+              })}
+            </Button>
+          )}
+          <Button onClick={handleTask} disabled={!files.length}>
+            {t('home:startTask')}
+          </Button>
+        </>
       )}
       {taskStatus === 'running' && (
         <>

--- a/renderer/lib/taskWorkflow.ts
+++ b/renderer/lib/taskWorkflow.ts
@@ -1,0 +1,95 @@
+import { IFiles } from '../../types';
+
+export type TaskStepKey =
+  | 'extractAudio'
+  | 'extractSubtitle'
+  | 'translateSubtitle';
+
+type TaskType = 'generateAndTranslate' | 'generateOnly' | 'translateOnly';
+
+interface TaskFormData {
+  taskType?: TaskType;
+  translateProvider?: string;
+}
+
+const TASK_STATE_KEYS = [
+  'extractAudio',
+  'extractSubtitle',
+  'translateSubtitle',
+  'prepareSubtitle',
+  'processFile',
+] as const;
+
+function isSubtitlePath(filePath?: string): boolean {
+  return /\.(srt|vtt|ass|ssa|lrc)$/i.test(filePath || '');
+}
+
+function getTaskType(formData: TaskFormData): TaskType {
+  return formData?.taskType || 'generateAndTranslate';
+}
+
+function shouldTranslate(formData: TaskFormData): boolean {
+  const taskType = getTaskType(formData);
+  return (
+    (taskType === 'generateAndTranslate' || taskType === 'translateOnly') &&
+    formData?.translateProvider !== '-1'
+  );
+}
+
+export function getRequiredTaskSteps(
+  file: IFiles,
+  formData: TaskFormData,
+): TaskStepKey[] {
+  const taskType = getTaskType(formData);
+  const steps: TaskStepKey[] = [];
+
+  if (taskType !== 'translateOnly' && !isSubtitlePath(file.filePath)) {
+    steps.push('extractAudio', 'extractSubtitle');
+  }
+
+  if (shouldTranslate(formData)) {
+    steps.push('translateSubtitle');
+  }
+
+  return steps;
+}
+
+export function isTaskComplete(file: IFiles, formData: TaskFormData): boolean {
+  const steps = getRequiredTaskSteps(file, formData);
+  return steps.length > 0 && steps.every((step) => file[step] === 'done');
+}
+
+export function hasTaskFailure(file: IFiles, formData: TaskFormData): boolean {
+  return getRequiredTaskSteps(file, formData).some(
+    (step) => file[step] === 'error',
+  );
+}
+
+export function getRunnableTaskFiles(
+  files: IFiles[],
+  formData: TaskFormData,
+): IFiles[] {
+  return files.filter((file) => {
+    const steps = getRequiredTaskSteps(file, formData);
+    return steps.length > 0 && !isTaskComplete(file, formData);
+  });
+}
+
+export function getFailedTaskFiles(
+  files: IFiles[],
+  formData: TaskFormData,
+): IFiles[] {
+  return files.filter((file) => hasTaskFailure(file, formData));
+}
+
+export function resetTaskRunState(file: IFiles): IFiles {
+  const nextFile = { ...file };
+
+  TASK_STATE_KEYS.forEach((key) => {
+    delete nextFile[key];
+    delete nextFile[`${key}Progress`];
+    delete nextFile[`${key}Error`];
+  });
+
+  return nextFile;
+}

--- a/renderer/pages/[locale]/home.tsx
+++ b/renderer/pages/[locale]/home.tsx
@@ -17,7 +17,7 @@ import { IFiles } from '../../../types';
 import path from 'path';
 
 export default function Component() {
-  const [files, setFiles] = useState([]);
+  const [files, setFiles] = useState<IFiles[]>([]);
   const [proofreadFile, setProofreadFile] = useState<IFiles | null>(null);
   const { systemInfo } = useSystemInfo();
   const { form, formData } = useFormConfig();
@@ -171,6 +171,7 @@ export default function Component() {
         <TaskControls
           formData={formData}
           files={files}
+          setFiles={setFiles}
           className="mt-auto flex-shrink-0 pt-4"
         />
       </div>

--- a/renderer/public/locales/en/home.json
+++ b/renderer/public/locales/en/home.json
@@ -52,6 +52,8 @@
   "translateSubtitle": "Translate Subtitle",
   "noTask": "No tasks to be processed",
   "allFilesProcessed": "All files have been processed",
+  "retryFailedTasks": "Retry Failed ({{count}})",
+  "noFailedTasks": "No failed tasks to retry",
   "restartTask": "Restart Task",
   "resumeTask": "Resume Task",
   "cancelTask": "Cancel Task",

--- a/renderer/public/locales/zh/home.json
+++ b/renderer/public/locales/zh/home.json
@@ -58,6 +58,8 @@
   "translateSubtitle": "翻译字幕",
   "noTask": "没有任务需要处理",
   "allFilesProcessed": "所有文件已处理完成",
+  "retryFailedTasks": "重试失败任务 ({{count}})",
+  "noFailedTasks": "没有失败任务需要重试",
   "restartTask": "重启任务",
   "resumeTask": "恢复任务",
   "cancelTask": "取消任务",

--- a/types/types.ts
+++ b/types/types.ts
@@ -5,21 +5,36 @@ export interface ISystemInfo {
   totalMemoryGB?: number;
 }
 
+export type TaskStepStatus = 'loading' | 'done' | 'error';
+
 export interface IFiles {
   uuid: string;
   filePath: string;
   fileName: string;
   fileExtension: string;
   directory: string;
-  extractAudio?: boolean;
-  extractSubtitle?: boolean;
-  translateSubtitle?: boolean;
+  extractAudio?: TaskStepStatus;
+  extractSubtitle?: TaskStepStatus;
+  translateSubtitle?: TaskStepStatus;
+  prepareSubtitle?: TaskStepStatus;
+  processFile?: TaskStepStatus;
+  extractAudioProgress?: number;
+  extractSubtitleProgress?: number;
+  translateSubtitleProgress?: number;
+  prepareSubtitleProgress?: number;
+  processFileProgress?: number;
+  extractAudioError?: string;
+  extractSubtitleError?: string;
+  translateSubtitleError?: string;
+  prepareSubtitleError?: string;
+  processFileError?: string;
   audioFile?: string;
   srtFile?: string;
   tempSrtFile?: string;
   tempAudioFile?: string;
   translatedSrtFile?: string;
   tempTranslatedSrtFile?: string;
+  [key: string]: unknown;
 }
 
 export interface IFormData {


### PR DESCRIPTION
## Summary
- add shared task workflow helpers to determine required steps and task completion/failure states
- make the normal Start Task flow skip completed files and queue only unfinished runnable files
- add a Retry Failed Tasks action that queues only failed files and clears stale step state before retrying
- type task status/progress/error fields explicitly and add English/Chinese labels for the retry action

## Testing
- `npm run build`
- `git diff --check`
- locale JSON parse check for `renderer/public/locales/en/home.json` and `renderer/public/locales/zh/home.json`

Closes #222