### PR TITLE
修复腾讯云翻译默认请求频率

### DIFF
--- a/main/helpers/providerManager.ts
+++ b/main/helpers/providerManager.ts
@@ -1,13 +1,14 @@
 import {
   Provider,
   PROVIDER_TYPES,
+  TENCENT_DEFAULT_REQUEST_INTERVAL_SECONDS,
   defaultSystemPrompt,
   HISTORICAL_DEFAULT_PROMPTS,
 } from '../../types/provider';
 import { store } from './store';
 import { logMessage } from './logger';
 
-const CURRENT_PROVIDER_VERSION = 16;
+const CURRENT_PROVIDER_VERSION = 17;
 
 export async function getAndInitializeProviders(): Promise<Provider[]> {
   try {
@@ -70,13 +71,25 @@ function shouldUpdateSystemPrompt(currentPrompt: string | undefined): boolean {
   );
 }
 
+function withTencentRateLimitDefaults(provider: any): any {
+  if (provider.id !== 'tencent') return provider;
+
+  const currentInterval = Number(provider.requestInterval || 0);
+  if (currentInterval > 0) return provider;
+
+  return {
+    ...provider,
+    requestInterval: TENCENT_DEFAULT_REQUEST_INTERVAL_SECONDS,
+  };
+}
+
 function migrateProviders(oldProviders: any[]): Provider[] {
   // 分离内置和自定义服务商
   const builtinProviders = oldProviders
     .filter((p) => PROVIDER_TYPES.some((type) => type.id === p.id))
     .map((p) => {
       const template = PROVIDER_TYPES.find((type) => type.id === p.id)!;
-      return {
+      return withTencentRateLimitDefaults({
         ...p,
         type: p.id,
         isAi: template.isAi || false,
@@ -95,7 +108,7 @@ function migrateProviders(oldProviders: any[]): Provider[] {
               ?.defaultValue ||
             'json_object',
         }),
-      };
+      });
     });
 
   const customProviders = oldProviders

--- a/renderer/components/ProviderForm.tsx
+++ b/renderer/components/ProviderForm.tsx
@@ -281,6 +281,7 @@ export const ProviderForm: React.FC<ProviderFormProps> = ({
           <Input
             id={fieldDomId(field.key)}
             type="number"
+            step={field.step}
             value={value}
             onChange={(e) => onChange(field.key, e.target.value)}
             placeholder={fieldPlaceholder(field.placeholder)}

--- a/types/provider.ts
+++ b/types/provider.ts
@@ -12,6 +12,7 @@ export type ProviderField = {
   placeholder?: string;
   required?: boolean;
   defaultValue?: string | number | boolean;
+  step?: string | number;
   tips?: string;
   options?: string[];
 };
@@ -102,6 +103,7 @@ export interface ParameterTemplate {
 }
 
 export const defaultUserPrompt = '${content}';
+export const TENCENT_DEFAULT_REQUEST_INTERVAL_SECONDS = 0.25;
 
 /**
  * 历史版本的默认系统提示词，用于迁移时判断用户是否修改过
@@ -174,8 +176,14 @@ const FIELD_REQUEST_INTERVAL: ProviderField = {
   label: 'requestInterval',
   type: 'number',
   defaultValue: 0,
+  step: 0.1,
   tips: 'requestIntervalTip',
   placeholder: 'phRequestInterval',
+};
+
+const tencentRequestIntervalField: ProviderField = {
+  ...FIELD_REQUEST_INTERVAL,
+  defaultValue: TENCENT_DEFAULT_REQUEST_INTERVAL_SECONDS,
 };
 
 const FIELD_SYSTEM_PROMPT: ProviderField = {
@@ -233,9 +241,10 @@ const aiCommonFields = (overrides?: {
 const apiBatchFields = (
   defaultBatchSize: number,
   batchSizeTips: string,
+  requestIntervalField: ProviderField = FIELD_REQUEST_INTERVAL,
 ): ProviderField[] => [
   batchSizeField(defaultBatchSize, batchSizeTips),
-  FIELD_REQUEST_INTERVAL,
+  requestIntervalField,
 ];
 
 // ============================================================
@@ -435,7 +444,7 @@ export const PROVIDER_TYPES: ProviderType[] = [
         tips: 'regionTencentTips',
         placeholder: 'phTencentRegion',
       },
-      ...apiBatchFields(1, 'batchSizeTencentTips'),
+      ...apiBatchFields(1, 'batchSizeTencentTips', tencentRequestIntervalField),
     ],
   },
   {


### PR DESCRIPTION
﻿## 变更

- 将腾讯云翻译的默认请求间隔调整为 0.25 秒，避免连续字幕逐条翻译时超过 5 QPS 限制。
- 升级 provider 配置版本，并在迁移时把腾讯云旧默认的 0 秒间隔更新为 0.25 秒；用户手动设置的大于 0 的间隔会保留。
- 让 provider 数字输入支持小数步进，便于配置 0.25 秒这类限流值。

## 原因

腾讯云文本翻译接口每次只翻译一段文本，虽然默认 batchSize 已是 1，但旧默认请求间隔为 0，会让连续字幕请求在 1 秒内超过 5 次，触发：

`Your current request times equals to 6 in a second, which exceeds the frequency limit 5 for a second.`

Fixes #334

## 验证

- `npm run check:i18n`
- `npx prettier --check types\provider.ts main\helpers\providerManager.ts renderer\components\ProviderForm.tsx`
- 临时 Node 脚本断言腾讯云默认请求间隔和旧配置迁移行为
- 临时 TS/TSX transpile diagnostics 检查 touched files
- `git diff --check`
