### PR TITLE
按语音结束时间收敛字幕显示

### DIFF
--- a/main/helpers/engines/builtinEngine.ts
+++ b/main/helpers/engines/builtinEngine.ts
@@ -4,6 +4,7 @@ import type { EngineStatus } from '../../../types/engine';
 import { getPath, loadWhisperAddon } from '../whisper';
 import { logMessage, store } from '../storeManager';
 import { formatSrtContent } from '../fileUtils';
+import { trimSubtitleTrailingSilence } from '../subtitleTiming';
 import { getExtraResourcesPath } from '../utils';
 import {
   getTaskContext,
@@ -127,7 +128,11 @@ async function transcribeBuiltin(ctx: TranscribeContext): Promise<string> {
       throw new TaskCancelledError();
     }
 
-    const formattedSrt = formatSrtContent(result?.transcription || []);
+    const subtitles = trimSubtitleTrailingSilence(
+      result?.transcription || [],
+      tempAudioFile,
+    );
+    const formattedSrt = formatSrtContent(subtitles);
     await fs.promises.writeFile(srtFile, formattedSrt);
 
     event.sender.send('taskFileChange', { ...file, extractSubtitle: 'done' });

--- a/main/helpers/engines/fasterWhisperEngine.ts
+++ b/main/helpers/engines/fasterWhisperEngine.ts
@@ -13,6 +13,10 @@ import { formatSrtContent } from '../fileUtils';
 import { logMessage, store } from '../storeManager';
 import { getPythonRuntimeManager } from '../pythonRuntime';
 import {
+  subtitleCueFromSegment,
+  trimSubtitleTrailingSilence,
+} from '../subtitleTiming';
+import {
   getTaskContext,
   isTaskCancelledError,
   TaskCancelledError,
@@ -21,7 +25,6 @@ import { toFasterWhisperModel } from './modelMap';
 import {
   getNumericSetting,
   getWhisperLanguage,
-  secondsToSrtTime,
   getFasterWhisperAntiRepetitionParams,
 } from './transcribeShared';
 import type { TranscribeContext, TranscriptionEngineAdapter } from './types';
@@ -296,16 +299,11 @@ async function transcribeFasterWhisper(
     throw new TaskCancelledError();
   }
 
-  const formattedSrt = formatSrtContent(
-    (transcription?.segments || []).map(
-      (segment) =>
-        [
-          secondsToSrtTime(segment.start),
-          secondsToSrtTime(segment.end),
-          segment.text || '',
-        ] as [string, string, string],
-    ),
+  const subtitles = trimSubtitleTrailingSilence(
+    (transcription?.segments || []).map(subtitleCueFromSegment),
+    tempAudioFile,
   );
+  const formattedSrt = formatSrtContent(subtitles);
   await fs.promises.writeFile(srtFile, formattedSrt);
 
   event.sender.send('taskProgressChange', file, 'extractSubtitle', 100);

--- a/main/helpers/engines/fireRedEngine.ts
+++ b/main/helpers/engines/fireRedEngine.ts
@@ -16,7 +16,10 @@ import {
 import { formatSrtContent } from '../fileUtils';
 import { logMessage, store } from '../storeManager';
 import { getTaskContext, TaskCancelledError } from '../taskContext';
-import { secondsToSrtTime } from './transcribeShared';
+import {
+  subtitleCueFromSegment,
+  trimSubtitleTrailingSilence,
+} from '../subtitleTiming';
 import { buildFireRedParams } from './fireRedParams';
 import type { TranscribeContext, TranscriptionEngineAdapter } from './types';
 
@@ -123,16 +126,11 @@ async function transcribeFireRed(ctx: TranscribeContext): Promise<string> {
 
   if (signal?.aborted) throw new TaskCancelledError();
 
-  const formattedSrt = formatSrtContent(
-    (transcription?.segments || []).map(
-      (segment) =>
-        [
-          secondsToSrtTime(segment.start),
-          secondsToSrtTime(segment.end),
-          segment.text || '',
-        ] as [string, string, string],
-    ),
+  const subtitles = trimSubtitleTrailingSilence(
+    (transcription?.segments || []).map(subtitleCueFromSegment),
+    tempAudioFile,
   );
+  const formattedSrt = formatSrtContent(subtitles);
   await fs.promises.writeFile(srtFile, formattedSrt);
 
   event.sender.send('taskProgressChange', file, 'extractSubtitle', 100);

--- a/main/helpers/engines/funasrEngine.ts
+++ b/main/helpers/engines/funasrEngine.ts
@@ -17,7 +17,10 @@ import {
 import { formatSrtContent } from '../fileUtils';
 import { logMessage, store } from '../storeManager';
 import { getTaskContext, TaskCancelledError } from '../taskContext';
-import { secondsToSrtTime } from './transcribeShared';
+import {
+  subtitleCueFromSegment,
+  trimSubtitleTrailingSilence,
+} from '../subtitleTiming';
 import { buildFunasrParams } from './funasrParams';
 import type { TranscribeContext, TranscriptionEngineAdapter } from './types';
 
@@ -133,16 +136,11 @@ async function transcribeFunasr(ctx: TranscribeContext): Promise<string> {
 
   if (signal?.aborted) throw new TaskCancelledError();
 
-  const formattedSrt = formatSrtContent(
-    (transcription?.segments || []).map(
-      (segment) =>
-        [
-          secondsToSrtTime(segment.start),
-          secondsToSrtTime(segment.end),
-          segment.text || '',
-        ] as [string, string, string],
-    ),
+  const subtitles = trimSubtitleTrailingSilence(
+    (transcription?.segments || []).map(subtitleCueFromSegment),
+    tempAudioFile,
   );
+  const formattedSrt = formatSrtContent(subtitles);
   await fs.promises.writeFile(srtFile, formattedSrt);
 
   event.sender.send('taskProgressChange', file, 'extractSubtitle', 100);

--- a/main/helpers/engines/qwenEngine.ts
+++ b/main/helpers/engines/qwenEngine.ts
@@ -16,7 +16,10 @@ import {
 import { formatSrtContent } from '../fileUtils';
 import { logMessage, store } from '../storeManager';
 import { getTaskContext, TaskCancelledError } from '../taskContext';
-import { secondsToSrtTime } from './transcribeShared';
+import {
+  subtitleCueFromSegment,
+  trimSubtitleTrailingSilence,
+} from '../subtitleTiming';
 import { buildQwenParams } from './qwenParams';
 import type { TranscribeContext, TranscriptionEngineAdapter } from './types';
 
@@ -121,16 +124,11 @@ async function transcribeQwen(ctx: TranscribeContext): Promise<string> {
 
   if (signal?.aborted) throw new TaskCancelledError();
 
-  const formattedSrt = formatSrtContent(
-    (transcription?.segments || []).map(
-      (segment) =>
-        [
-          secondsToSrtTime(segment.start),
-          secondsToSrtTime(segment.end),
-          segment.text || '',
-        ] as [string, string, string],
-    ),
+  const subtitles = trimSubtitleTrailingSilence(
+    (transcription?.segments || []).map(subtitleCueFromSegment),
+    tempAudioFile,
   );
+  const formattedSrt = formatSrtContent(subtitles);
   await fs.promises.writeFile(srtFile, formattedSrt);
 
   event.sender.send('taskProgressChange', file, 'extractSubtitle', 100);

--- a/main/helpers/fileUtils.ts
+++ b/main/helpers/fileUtils.ts
@@ -68,12 +68,45 @@ export function ensureTempDir() {
 /**
  * 格式化SRT内容
  */
+export function subtitleTimeToSeconds(time?: string): number | null {
+  if (!time) return null;
+  const normalized = time.trim().replace(',', '.');
+  const parts = normalized.split(':').map((part) => Number(part));
+  if (!parts.length || parts.some((part) => Number.isNaN(part))) return null;
+
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  if (parts.length === 2) return parts[0] * 60 + parts[1];
+  return parts[0];
+}
+
+export function secondsToSubtitleTime(seconds: number) {
+  const totalMilliseconds = Math.max(0, Math.round(seconds * 1000));
+  const milliseconds = totalMilliseconds % 1000;
+  const totalSeconds = Math.floor(totalMilliseconds / 1000);
+  const displaySeconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const hours = Math.floor(totalMinutes / 60);
+
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(
+    2,
+    '0',
+  )}:${String(displaySeconds).padStart(2, '0')},${String(milliseconds).padStart(
+    3,
+    '0',
+  )}`;
+}
+
+function normalizeSrtTime(time: string) {
+  return time.replace('.', ',');
+}
+
 export function formatSrtContent(subtitles: [string, string, string][]) {
   return subtitles
     .map((subtitle, index) => {
       const [startTime, endTime, text] = subtitle;
       // SRT格式：序号 + 时间码 + 文本 + 空行
-      return `${index + 1}\n${startTime.replace('.', ',')} --> ${endTime.replace('.', ',')}\n${text.trim()}\n`;
+      return `${index + 1}\n${normalizeSrtTime(startTime)} --> ${normalizeSrtTime(endTime)}\n${text.trim()}\n`;
     })
     .join('\n');
 }

--- a/main/helpers/subtitleTiming.ts
+++ b/main/helpers/subtitleTiming.ts
@@ -1,0 +1,261 @@
+import fs from 'fs';
+import { logMessage } from './storeManager';
+import { secondsToSubtitleTime, subtitleTimeToSeconds } from './fileUtils';
+
+export type SubtitleCue = [string, string, string];
+
+type SegmentWithOptionalWords = {
+  start: number;
+  end: number;
+  text?: string;
+  words?: Array<{ start?: number; end?: number; word?: string }>;
+};
+
+type WavInfo = {
+  dataOffset: number;
+  dataSize: number;
+  sampleRate: number;
+  channels: number;
+};
+
+type AudioEnergy = {
+  frameDurationSeconds: number;
+  frameDb: number[];
+  thresholdDb: number;
+};
+
+const FRAME_MS = 20;
+const WORD_END_PADDING_SECONDS = 0.15;
+const SILENCE_END_PADDING_SECONDS = 0.25;
+const MIN_TRAILING_SILENCE_SECONDS = 0.65;
+const MIN_SUBTITLE_DURATION_SECONDS = 0.25;
+
+export function subtitleCueFromSegment(
+  segment: SegmentWithOptionalWords,
+): SubtitleCue {
+  return [
+    secondsToSubtitleTime(segment.start),
+    secondsToSubtitleTime(getSpeechEndFromWords(segment) ?? segment.end),
+    segment.text || '',
+  ];
+}
+
+function getSpeechEndFromWords(segment: SegmentWithOptionalWords) {
+  const words = segment.words || [];
+  for (let i = words.length - 1; i >= 0; i -= 1) {
+    const word = words[i];
+    if (typeof word.word === 'string' && !word.word.trim()) continue;
+    const end = Number(word.end);
+    if (Number.isFinite(end) && end > segment.start && end <= segment.end + 1) {
+      return Math.min(segment.end, end + WORD_END_PADDING_SECONDS);
+    }
+  }
+  return null;
+}
+
+export function trimSubtitleTrailingSilence(
+  subtitles: SubtitleCue[],
+  audioFile?: string,
+): SubtitleCue[] {
+  if (!audioFile || !fs.existsSync(audioFile) || subtitles.length === 0) {
+    return subtitles;
+  }
+
+  try {
+    const energy = analyzePcm16WavEnergy(audioFile);
+    if (!energy) return subtitles;
+
+    return subtitles.map((subtitle, index) =>
+      trimSubtitleCue(subtitle, subtitles[index + 1], energy),
+    );
+  } catch (error) {
+    logMessage(`subtitle silence trim skipped: ${error}`, 'warning');
+    return subtitles;
+  }
+}
+
+function trimSubtitleCue(
+  subtitle: SubtitleCue,
+  nextSubtitle: SubtitleCue | undefined,
+  energy: AudioEnergy,
+): SubtitleCue {
+  const [startTime, endTime, text] = subtitle;
+  const startSeconds = subtitleTimeToSeconds(startTime);
+  const endSeconds = subtitleTimeToSeconds(endTime);
+  const nextStartSeconds = subtitleTimeToSeconds(nextSubtitle?.[0]);
+
+  if (
+    startSeconds === null ||
+    endSeconds === null ||
+    endSeconds <= startSeconds + MIN_SUBTITLE_DURATION_SECONDS
+  ) {
+    return subtitle;
+  }
+
+  const lastSpeechFrame = findLastSpeechFrame(energy, startSeconds, endSeconds);
+  if (lastSpeechFrame === null) return subtitle;
+
+  const speechEndSeconds =
+    (lastSpeechFrame + 1) * energy.frameDurationSeconds +
+    SILENCE_END_PADDING_SECONDS;
+  const nextStartCap =
+    nextStartSeconds !== null && nextStartSeconds > startSeconds
+      ? nextStartSeconds
+      : Number.POSITIVE_INFINITY;
+  const trimmedEndSeconds = Math.min(
+    endSeconds,
+    speechEndSeconds,
+    nextStartCap,
+  );
+
+  if (
+    endSeconds - trimmedEndSeconds < MIN_TRAILING_SILENCE_SECONDS ||
+    trimmedEndSeconds <= startSeconds + MIN_SUBTITLE_DURATION_SECONDS
+  ) {
+    return subtitle;
+  }
+
+  return [startTime, secondsToSubtitleTime(trimmedEndSeconds), text];
+}
+
+function findLastSpeechFrame(
+  energy: AudioEnergy,
+  startSeconds: number,
+  endSeconds: number,
+) {
+  const startFrame = Math.max(
+    0,
+    Math.floor(startSeconds / energy.frameDurationSeconds),
+  );
+  const endFrame = Math.min(
+    energy.frameDb.length - 1,
+    Math.ceil(endSeconds / energy.frameDurationSeconds) - 1,
+  );
+
+  for (let i = endFrame; i >= startFrame; i -= 1) {
+    if (energy.frameDb[i] >= energy.thresholdDb) return i;
+  }
+  return null;
+}
+
+function analyzePcm16WavEnergy(audioFile: string): AudioEnergy | null {
+  const buffer = fs.readFileSync(audioFile);
+  const wavInfo = parsePcm16Wav(buffer);
+  if (!wavInfo) return null;
+
+  const samplesPerFrame = Math.max(
+    1,
+    Math.round((wavInfo.sampleRate * FRAME_MS) / 1000),
+  );
+  const frameDurationSeconds = samplesPerFrame / wavInfo.sampleRate;
+  const bytesPerSample = 2;
+  const bytesPerSampleFrame = bytesPerSample * wavInfo.channels;
+  const sampleFrames = Math.floor(wavInfo.dataSize / bytesPerSampleFrame);
+  const frameCount = Math.ceil(sampleFrames / samplesPerFrame);
+  const frameDb: number[] = [];
+  const dataEnd = wavInfo.dataOffset + wavInfo.dataSize;
+
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    const firstSampleFrame = frame * samplesPerFrame;
+    const lastSampleFrame = Math.min(
+      sampleFrames,
+      firstSampleFrame + samplesPerFrame,
+    );
+    let sumSquares = 0;
+    let count = 0;
+
+    for (
+      let sampleFrame = firstSampleFrame;
+      sampleFrame < lastSampleFrame;
+      sampleFrame += 1
+    ) {
+      for (let channel = 0; channel < wavInfo.channels; channel += 1) {
+        const byteOffset =
+          wavInfo.dataOffset +
+          (sampleFrame * wavInfo.channels + channel) * bytesPerSample;
+        if (byteOffset + bytesPerSample > dataEnd) break;
+        const sample = buffer.readInt16LE(byteOffset) / 32768;
+        sumSquares += sample * sample;
+        count += 1;
+      }
+    }
+
+    const rms = Math.sqrt(sumSquares / Math.max(count, 1));
+    frameDb.push(20 * Math.log10(Math.max(rms, 1e-8)));
+  }
+
+  if (!frameDb.length) return null;
+  return {
+    frameDurationSeconds,
+    frameDb,
+    thresholdDb: estimateSpeechThresholdDb(frameDb),
+  };
+}
+
+function parsePcm16Wav(buffer: Buffer): WavInfo | null {
+  if (
+    buffer.length < 44 ||
+    buffer.toString('ascii', 0, 4) !== 'RIFF' ||
+    buffer.toString('ascii', 8, 12) !== 'WAVE'
+  ) {
+    return null;
+  }
+
+  let offset = 12;
+  let sampleRate = 0;
+  let channels = 0;
+  let audioFormat = 0;
+  let bitsPerSample = 0;
+  let dataOffset = 0;
+  let dataSize = 0;
+
+  while (offset + 8 <= buffer.length) {
+    const id = buffer.toString('ascii', offset, offset + 4);
+    const size = buffer.readUInt32LE(offset + 4);
+    const chunkStart = offset + 8;
+
+    if (id === 'fmt ' && chunkStart + size <= buffer.length) {
+      audioFormat = buffer.readUInt16LE(chunkStart);
+      channels = buffer.readUInt16LE(chunkStart + 2);
+      sampleRate = buffer.readUInt32LE(chunkStart + 4);
+      bitsPerSample = buffer.readUInt16LE(chunkStart + 14);
+    } else if (id === 'data') {
+      dataOffset = chunkStart;
+      dataSize = Math.min(size, buffer.length - chunkStart);
+    }
+
+    offset = chunkStart + size + (size % 2);
+  }
+
+  if (
+    audioFormat !== 1 ||
+    bitsPerSample !== 16 ||
+    channels <= 0 ||
+    sampleRate <= 0 ||
+    dataOffset <= 0 ||
+    dataSize <= 0
+  ) {
+    return null;
+  }
+
+  return { dataOffset, dataSize, sampleRate, channels };
+}
+
+function estimateSpeechThresholdDb(frameDb: number[]) {
+  const sorted = frameDb
+    .filter((value) => Number.isFinite(value))
+    .sort((a, b) => a - b);
+  if (!sorted.length) return -50;
+
+  const noiseFloorDb = percentile(sorted, 0.15);
+  const speechPeakDb = percentile(sorted, 0.95);
+  return Math.max(Math.min(noiseFloorDb + 12, speechPeakDb - 6), -55);
+}
+
+function percentile(sortedValues: number[], ratio: number) {
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.round((sortedValues.length - 1) * ratio)),
+  );
+  return sortedValues[index];
+}


### PR DESCRIPTION
﻿## 变更
- 转写生成 SRT 前，自动把每条字幕的结束时间收敛到实际语音结束附近，避免后续静默区间继续显示上一句字幕。
- faster-whisper 优先使用词级时间戳的末词结束时间。
- builtin / faster-whisper / FunASR / Qwen / FireRed 统一增加 WAV 尾部静音检测兜底，把明显长静默从字幕尾部裁掉。
- 不新增手动“最大显示时长”设置，目标是自动做到“没说话时没字幕”。

## 背景
Closes #55。

旧草稿 #340 是按最大显示秒数做的手动限制，方向不对，已经关闭。这个 PR 改为自动识别字幕尾部的真实语音结束点，减少用户后期反复微调时间轴。

## 验证
- 切换到干净的 `upstream/main` 新分支后应用本修复。
- 合成 16kHz PCM WAV：前 2 秒有声音，2-12 秒静音，12-14 秒再次有声音；断言第一条 `00:00:00 --> 00:00:12` 会自动收回到 2 秒多，第二条保持不变。
- 断言 faster-whisper 词级时间戳会使用末词 end + padding，而不是 segment.end。
- `npm run check:i18n`
- `npx prettier --check main/helpers/fileUtils.ts main/helpers/subtitleTiming.ts main/helpers/engines/builtinEngine.ts main/helpers/engines/fasterWhisperEngine.ts main/helpers/engines/funasrEngine.ts main/helpers/engines/qwenEngine.ts main/helpers/engines/fireRedEngine.ts`
- `git diff --cached --check`
- 触达 TS 文件 `transpileModule` 诊断通过

## 已知验证限制
- `npm run test:engines` 在当前本地环境失败于 `node_modules/electron` 安装状态：`Electron failed to install correctly`，未跑到测试断言。
- 目前本地主要使用合成 WAV 做了行为验证；后续可以用真实长静默素材进一步调阈值。
