### PR TITLE
兼容误命名的字幕文件格式识别

### DIFF
--- a/main/helpers/fileProcessor.ts
+++ b/main/helpers/fileProcessor.ts
@@ -231,9 +231,14 @@ export async function processFile(
     const { filePath, fileName, fileExtension, directory } = file;
     console.log('filePath', file);
 
-    const isSubtitleFile = ['.srt', '.vtt', '.ass', '.ssa', '.lrc'].includes(
-      fileExtension,
-    );
+    const isSubtitleFile = [
+      '.srt',
+      '.vtt',
+      '.ass',
+      '.ssa',
+      '.lrc',
+      '.txt',
+    ].includes(fileExtension);
     logMessage(`begin process ${fileName} with task type: ${taskType}`, 'info');
 
     // 确定是否需要生成字幕

--- a/main/helpers/ipcHandlers.ts
+++ b/main/helpers/ipcHandlers.ts
@@ -62,6 +62,7 @@ export const SUBTITLE_EXTENSIONS = [
 ];
 
 const IMPORTABLE_SUBTITLE_EXTENSIONS = [...SUBTITLE_EXTENSIONS, '.txt'];
+const SUBTITLE_CONTENT_PROBE_BYTES = 50 * 1024;
 
 // 判断文件是否为媒体文件
 export function isMediaFile(filePath: string): boolean {
@@ -75,13 +76,24 @@ export function isSubtitleFile(filePath: string): boolean {
   return SUBTITLE_EXTENSIONS.includes(ext);
 }
 
+async function readSubtitleProbeContent(filePath: string): Promise<string> {
+  const fileHandle = await fs.promises.open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(SUBTITLE_CONTENT_PROBE_BYTES);
+    const { bytesRead } = await fileHandle.read(buffer, 0, buffer.length, 0);
+    return buffer.subarray(0, bytesRead).toString('utf-8');
+  } finally {
+    await fileHandle.close();
+  }
+}
+
 async function isImportableSubtitleFile(filePath: string): Promise<boolean> {
   const ext = path.extname(filePath).toLowerCase();
   if (!IMPORTABLE_SUBTITLE_EXTENSIONS.includes(ext)) return false;
-  if (path.extname(filePath).toLowerCase() !== '.txt') return true;
+  if (ext !== '.txt') return true;
 
   try {
-    const content = await fs.promises.readFile(filePath, 'utf-8');
+    const content = await readSubtitleProbeContent(filePath);
     return detectSubtitleFormatFromContent(filePath, content) !== 'txt';
   } catch {
     return false;

--- a/main/helpers/ipcHandlers.ts
+++ b/main/helpers/ipcHandlers.ts
@@ -8,6 +8,7 @@ import { CONTENT_TEMPLATES } from '../translate/constants';
 import { renderTemplate, getExtraResourcesPath } from './utils';
 import {
   detectSubtitleFormat,
+  detectSubtitleFormatFromContent,
   parseSubtitleEntries,
   parseStartEndTime,
   getSubtitleFileHeader,
@@ -60,6 +61,8 @@ export const SUBTITLE_EXTENSIONS = [
   '.lrc',
 ];
 
+const IMPORTABLE_SUBTITLE_EXTENSIONS = [...SUBTITLE_EXTENSIONS, '.txt'];
+
 // 判断文件是否为媒体文件
 export function isMediaFile(filePath: string): boolean {
   const ext = path.extname(filePath).toLowerCase();
@@ -72,6 +75,19 @@ export function isSubtitleFile(filePath: string): boolean {
   return SUBTITLE_EXTENSIONS.includes(ext);
 }
 
+async function isImportableSubtitleFile(filePath: string): Promise<boolean> {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!IMPORTABLE_SUBTITLE_EXTENSIONS.includes(ext)) return false;
+  if (path.extname(filePath).toLowerCase() !== '.txt') return true;
+
+  try {
+    const content = await fs.promises.readFile(filePath, 'utf-8');
+    return detectSubtitleFormatFromContent(filePath, content) !== 'txt';
+  } catch {
+    return false;
+  }
+}
+
 // 递归获取文件夹中的符合任务类型的文件
 async function getMediaFilesFromDirectory(
   directoryPath: string,
@@ -79,7 +95,9 @@ async function getMediaFilesFromDirectory(
 ): Promise<string[]> {
   // 根据任务类型选择扩展名
   const supportedExtensions =
-    taskType === 'translate' ? SUBTITLE_EXTENSIONS : MEDIA_EXTENSIONS;
+    taskType === 'translate'
+      ? IMPORTABLE_SUBTITLE_EXTENSIONS
+      : MEDIA_EXTENSIONS;
 
   const files: string[] = [];
 
@@ -99,9 +117,13 @@ async function getMediaFilesFromDirectory(
         );
         files.push(...subDirFiles);
       } else if (entry.isFile()) {
-        // 检查文件扩展名是否受支持
-        const ext = path.extname(entry.name).toLowerCase();
-        if (supportedExtensions.includes(ext)) {
+        if (
+          taskType === 'translate'
+            ? await isImportableSubtitleFile(fullPath)
+            : supportedExtensions.includes(
+                path.extname(entry.name).toLowerCase(),
+              )
+        ) {
           files.push(fullPath);
         }
       }
@@ -126,7 +148,7 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
 
     const extensions =
       fileType === 'srt'
-        ? SUBTITLE_EXTENSIONS.map((ext) => ext.substring(1))
+        ? IMPORTABLE_SUBTITLE_EXTENSIONS.map((ext) => ext.substring(1))
         : MEDIA_EXTENSIONS.map((ext) => ext.substring(1));
 
     // macOS 支持同时选择文件和文件夹；Windows/Linux 两者互斥，仅支持选择文件
@@ -152,7 +174,12 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
         if (stats.isDirectory()) {
           const dirFiles = await getMediaFilesFromDirectory(filePath, taskType);
           allValidPaths.push(...dirFiles);
-        } else if (stats.isFile()) {
+        } else if (
+          stats.isFile() &&
+          (taskType === 'translate'
+            ? await isImportableSubtitleFile(filePath)
+            : isMediaFile(filePath))
+        ) {
           allValidPaths.push(filePath);
         }
       } catch (error) {
@@ -196,7 +223,8 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
           // 如果是文件，根据任务类型过滤
           // 根据任务类型决定添加哪种文件
           if (
-            (taskType === 'translate' && isSubtitleFile(filePath)) ||
+            (taskType === 'translate' &&
+              (await isImportableSubtitleFile(filePath))) ||
             (taskType !== 'translate' && isMediaFile(filePath))
           ) {
             allValidPaths.push(filePath);
@@ -219,7 +247,7 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
         return [];
       }
       const content = await fs.promises.readFile(filePath, 'utf-8');
-      const format = detectSubtitleFormat(filePath);
+      const format = detectSubtitleFormatFromContent(filePath, content);
       return parseSubtitleEntries(content, format);
     } catch (error) {
       logMessage(`读取字幕文件错误: ${error.message}`, 'error');
@@ -234,7 +262,7 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
         return { error: `File not found: ${filePath}` };
       }
       const content = await fs.promises.readFile(filePath, 'utf-8');
-      const format = detectSubtitleFormat(filePath);
+      const format = detectSubtitleFormatFromContent(filePath, content);
       const vtt = convertSubtitleContent(content, format, 'vtt');
       return { content: vtt };
     } catch (error) {
@@ -388,9 +416,16 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
         title,
         filters: filters.length > 0 ? filters : undefined,
       });
+      const selectedPath = result.filePaths[0] || null;
+      const filePath =
+        type === 'subtitle' && selectedPath
+          ? (await isImportableSubtitleFile(selectedPath))
+            ? selectedPath
+            : null
+          : selectedPath;
 
       return {
-        filePath: result.filePaths[0] || null,
+        filePath,
         canceled: result.canceled,
       };
     },
@@ -437,9 +472,19 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
         title,
         filters: filters.length > 0 ? filters : undefined,
       });
+      const filePaths =
+        type === 'subtitle'
+          ? (
+              await Promise.all(
+                result.filePaths.map(async (filePath) =>
+                  (await isImportableSubtitleFile(filePath)) ? filePath : null,
+                ),
+              )
+            ).filter((filePath): filePath is string => Boolean(filePath))
+          : result.filePaths;
 
       return {
-        filePaths: result.filePaths,
+        filePaths,
         canceled: result.canceled,
       };
     },

--- a/main/helpers/subtitleFormats.ts
+++ b/main/helpers/subtitleFormats.ts
@@ -64,6 +64,11 @@ const FORMAT_TO_EXT: Record<SubtitleFormat, string> = {
   txt: '.txt',
 };
 
+const TIMESTAMP_PATTERN = String.raw`(?:\d{1,3}:)?\d{1,2}:\d{2}(?:[,.]\d{1,6})?`;
+const TIMING_LINE_PATTERN = new RegExp(
+  `${TIMESTAMP_PATTERN}\\s*-->\\s*${TIMESTAMP_PATTERN}`,
+);
+
 /** 根据文件路径/扩展名推断字幕格式，未知时返回 null。 */
 export function detectSubtitleFormatByExtension(
   filePath: string,
@@ -96,7 +101,7 @@ export function detectSubtitleContentFormat(
   const timingLine = text
     .split('\n')
     .map((line) => line.trim())
-    .find((line) => /-->/.test(line));
+    .find((line) => TIMING_LINE_PATTERN.test(line));
 
   if (!timingLine) return null;
   if (/,/.test(timingLine)) return 'srt';

--- a/main/helpers/subtitleFormats.ts
+++ b/main/helpers/subtitleFormats.ts
@@ -64,11 +64,56 @@ const FORMAT_TO_EXT: Record<SubtitleFormat, string> = {
   txt: '.txt',
 };
 
-/** 根据文件路径/扩展名推断字幕格式，未知时回退为 srt。 */
-export function detectSubtitleFormat(filePath: string): SubtitleFormat {
+/** 根据文件路径/扩展名推断字幕格式，未知时返回 null。 */
+export function detectSubtitleFormatByExtension(
+  filePath: string,
+): SubtitleFormat | null {
   const match = /\.[^.\\/]+$/.exec(filePath || '');
   const ext = match ? match[0].toLowerCase() : '';
-  return EXT_TO_FORMAT[ext] || 'srt';
+  return EXT_TO_FORMAT[ext] || null;
+}
+
+/** 根据文件路径/扩展名推断字幕格式，未知时回退为 srt。 */
+export function detectSubtitleFormat(filePath: string): SubtitleFormat {
+  return detectSubtitleFormatByExtension(filePath) || 'srt';
+}
+
+/** 从内容识别常见字幕格式，用于兼容扩展名被改成 .txt 的时间轴字幕。 */
+export function detectSubtitleContentFormat(
+  content: string,
+): SubtitleFormat | null {
+  const text = normalizeLineEndings(content || '').trimStart();
+  if (!text.trim()) return null;
+
+  if (/^WEBVTT(?:\s|$)/i.test(text)) return 'vtt';
+  if (/^\[Script Info\]/im.test(text) || /^\[Events\]/im.test(text)) {
+    return 'ass';
+  }
+  if (/^\[\d{1,3}:\d{1,2}(?:[.:]\d{1,3})?\]/m.test(text)) {
+    return 'lrc';
+  }
+
+  const timingLine = text
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => /-->/.test(line));
+
+  if (!timingLine) return null;
+  if (/,/.test(timingLine)) return 'srt';
+  return 'vtt';
+}
+
+/**
+ * 优先按扩展名识别；当扩展名未知或为 .txt 时，再按内容识别实际时间轴格式。
+ * 这样普通 .txt 仍保持 txt 语义，但 WebVTT/SRT 内容误命名为 .txt 时可以导入。
+ */
+export function detectSubtitleFormatFromContent(
+  filePath: string,
+  content: string,
+): SubtitleFormat {
+  const extensionFormat = detectSubtitleFormatByExtension(filePath);
+  if (extensionFormat && extensionFormat !== 'txt') return extensionFormat;
+  return detectSubtitleContentFormat(content) || extensionFormat || 'srt';
 }
 
 /** 获取某格式对应的文件扩展名（含点）。 */

--- a/main/translate/index.ts
+++ b/main/translate/index.ts
@@ -5,7 +5,7 @@ import { Provider, TranslationResult } from './types';
 import { CONTENT_TEMPLATES } from './constants';
 import { createOrClearFile, appendToFile } from './utils/file';
 import {
-  detectSubtitleFormat,
+  detectSubtitleFormatFromContent,
   parseSubtitleEntries,
 } from '../helpers/subtitleFormats';
 import {
@@ -104,12 +104,17 @@ export default async function translate(
       'info',
     );
 
-    // 源字幕按扩展名自动识别格式（srt/vtt/ass/lrc），统一解析为内部 Subtitle 结构
+    // 源字幕按扩展名+内容自动识别格式（srt/vtt/ass/lrc），统一解析为内部 Subtitle 结构
     const rawSourceContent = await fs.promises.readFile(srtFile, 'utf-8');
     const subtitles = parseSubtitleEntries(
       rawSourceContent,
-      detectSubtitleFormat(srtFile),
+      detectSubtitleFormatFromContent(srtFile, rawSourceContent),
     );
+    if (subtitles.length === 0) {
+      throw new Error(
+        `无法读取字幕内容，请确认文件包含有效的字幕时间轴: ${srtFile}`,
+      );
+    }
 
     const templateData = {
       fileName,

--- a/renderer/lib/utils.ts
+++ b/renderer/lib/utils.ts
@@ -370,7 +370,9 @@ export const isSubtitleFile = (filePath) => {
     filePath?.endsWith('.srt') ||
     filePath?.endsWith('.ass') ||
     filePath?.endsWith('.ssa') ||
-    filePath?.endsWith('.vtt')
+    filePath?.endsWith('.vtt') ||
+    filePath?.endsWith('.lrc') ||
+    filePath?.endsWith('.txt')
   );
 };
 
@@ -452,6 +454,8 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   'vtt',
   'ass',
   'ssa',
+  'lrc',
+  'txt',
 ] as const;
 
 // 添加文件过滤方法


### PR DESCRIPTION
﻿## 背景

Closes #191

当前 main 已经可以按 `.vtt` 扩展名读取 WebVTT；#191 里更实际的问题是用户把 WebVTT/SRT 这类带时间轴的字幕内容改成 `.txt` 后，导入时会按纯文本处理，导致读取不到字幕时间轴。这个 PR 做一个小范围适配：对 `.txt` 或未知扩展名的字幕文件增加内容识别，识别到有效时间轴后按真实字幕格式解析。

## 改动

- 新增字幕内容识别：支持从内容识别 WebVTT、SRT、ASS/SSA、LRC。
- 翻译任务读取字幕时使用“扩展名 + 内容”识别，误命名为 `.txt` 的 WebVTT/SRT 可以正常解析。
- 翻译任务的文件导入、文件夹扫描和拖拽允许 `.txt` 候选，但只有内容能识别为时间轴字幕时才会接受。
- `readSubtitleFile` / `getSubtitleAsVtt` 同步使用内容识别，预览和转换路径保持一致。
- 普通纯文本 `.txt` 仍然保持 `txt` 语义，不会被当作有效字幕时间轴；通用字幕选择器也没有把 `.txt` 放进合并/校对的默认过滤范围，避免影响字幕合并等依赖正式字幕扩展名的入口。

## 验证

- 通过脚本验证：
  - `sample.txt` 中的 WebVTT 内容会识别为 `vtt`。
  - `sample.txt` 中的 SRT 内容会识别为 `srt`。
  - 普通纯文本 `.txt` 仍识别为 `txt`。
  - #191 示例 WebVTT 内容可解析出字幕条目，并可转换为 VTT 输出。
- `npm run check:i18n`
- `npx prettier --check main/helpers/subtitleFormats.ts main/helpers/ipcHandlers.ts main/helpers/fileProcessor.ts main/translate/index.ts renderer/lib/utils.ts`
- `git diff --check`
- touched TypeScript files transpile diagnostics passed

备注：本地 `npm run test:engines` 仍因 Electron 安装异常无法运行：`Electron failed to install correctly, please delete node_modules/electron and try installing again`。这看起来是当前本地 `node_modules/electron` 环境问题，不是本次测试断言失败。
