### PR TITLE
fix: abort in-flight translation requests

### DIFF
--- a/main/helpers/ipcProofreadHandlers.ts
+++ b/main/helpers/ipcProofreadHandlers.ts
@@ -41,7 +41,12 @@ import {
   TranslationResult,
   TranslatorFunction,
 } from '../translate/types';
-import { runWithTaskContext, isTaskCancelledError } from './taskContext';
+import {
+  runWithTaskContext,
+  isTaskCancelledError,
+  throwIfSignalCancelled,
+  waitForTaskDelay,
+} from './taskContext';
 
 // 校对批量操作（批量 AI 优化 / 重翻失败）取消注册表
 const batchAbortControllers = new Map<string, AbortController>();
@@ -606,7 +611,8 @@ Only respond with the translation, nothing else.`;
 
         if (result) {
           // 清理结果，移除可能的引号或多余空白
-          const cleanedResult = result
+          const resultText = Array.isArray(result) ? result.join('\n') : result;
+          const cleanedResult = resultText
             .trim()
             .replace(/^["']|["']$/g, '')
             .trim();
@@ -807,15 +813,20 @@ IMPORTANT: You MUST return a valid JSON object. Do NOT include any text before o
                 optimizedProvider,
                 sourceLanguage,
                 targetLanguage,
+                { signal: abortController.signal },
               );
+              throwIfSignalCancelled(abortController.signal);
+              const responseText = Array.isArray(response)
+                ? response.join('\n')
+                : response;
 
               logMessage(
-                `Batch ${currentBatchIndex} response: ${response}`,
+                `Batch ${currentBatchIndex} response: ${responseText}`,
                 'info',
               );
 
               // 解析响应
-              const parsedResponse = parseOptimizationResponse(response);
+              const parsedResponse = parseOptimizationResponse(responseText);
 
               if (parsedResponse && typeof parsedResponse === 'object') {
                 // 处理结果
@@ -858,15 +869,32 @@ IMPORTANT: You MUST return a valid JSON object. Do NOT include any text before o
                 throw new Error('无法解析 AI 响应');
               }
             } catch (error) {
+              if (isTaskCancelledError(error)) {
+                cancelled = true;
+                break;
+              }
+              if (abortController.signal.aborted) {
+                cancelled = true;
+                break;
+              }
               retryCount++;
               if (retryCount <= maxRetries) {
                 logMessage(
                   `Batch ${currentBatchIndex} failed, retry ${retryCount}/${maxRetries}: ${error}`,
                   'warning',
                 );
-                await new Promise((resolve) =>
-                  setTimeout(resolve, 1000 * retryCount),
-                );
+                try {
+                  await waitForTaskDelay(
+                    1000 * retryCount,
+                    abortController.signal,
+                  );
+                } catch (delayError) {
+                  if (isTaskCancelledError(delayError)) {
+                    cancelled = true;
+                    break;
+                  }
+                  throw delayError;
+                }
               } else {
                 logMessage(
                   `Batch ${currentBatchIndex} failed after ${maxRetries} retries: ${error}`,

--- a/main/helpers/providerManager.ts
+++ b/main/helpers/providerManager.ts
@@ -132,7 +132,7 @@ function migrateProviders(oldProviders: any[]): Provider[] {
               'json_object',
           }),
         }),
-      });
+      );
     });
 
   const customProviders = oldProviders

--- a/main/helpers/providerManager.ts
+++ b/main/helpers/providerManager.ts
@@ -132,7 +132,7 @@ function migrateProviders(oldProviders: any[]): Provider[] {
               'json_object',
           }),
         }),
-      );
+      });
     });
 
   const customProviders = oldProviders

--- a/main/helpers/taskContext.ts
+++ b/main/helpers/taskContext.ts
@@ -45,6 +45,43 @@ export function throwIfTaskCancelled(): void {
   if (isTaskCancelled()) throw new TaskCancelledError();
 }
 
+export function getTaskSignal(): AbortSignal | undefined {
+  return storage.getStore()?.signal;
+}
+
+export function throwIfSignalCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted || isTaskCancelled()) throw new TaskCancelledError();
+}
+
+export function waitForTaskDelay(
+  ms: number,
+  signal: AbortSignal | undefined = getTaskSignal(),
+): Promise<void> {
+  throwIfSignalCancelled(signal);
+  if (ms <= 0) return Promise.resolve();
+
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+    };
+
+    const onAbort = () => {
+      cleanup();
+      reject(new TaskCancelledError());
+    };
+
+    timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 /** whisper addon 因 AbortSignal 中断时抛出的错误（与 TaskCancelledError 统一处理） */
 export function isWhisperAbortError(error: unknown): boolean {
   if (isTaskCancelledError(error)) return true;

--- a/main/service/aliyun.ts
+++ b/main/service/aliyun.ts
@@ -3,6 +3,8 @@ import alimt20181012 from '@alicloud/alimt20181012';
 import * as $OpenApi from '@alicloud/openapi-client';
 import * as $Util from '@alicloud/tea-util';
 import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 // 客户端实例
 let client: any = null;
@@ -20,7 +22,9 @@ export default async function translate(
   proof: { apiKey: string; apiSecret: string; endpoint?: string },
   sourceLanguage: string,
   targetLanguage: string,
+  options?: TranslationRequestOptions,
 ) {
+  throwIfSignalCancelled(options?.signal);
   const {
     apiKey: accessKeyId,
     apiSecret: accessKeySecret,
@@ -60,6 +64,7 @@ export default async function translate(
         query,
         formatSourceLanguage,
         formatTargetLanguage,
+        options,
       );
     } else {
       // 单文本翻译，包装成批量处理
@@ -68,10 +73,12 @@ export default async function translate(
         [query],
         formatSourceLanguage,
         formatTargetLanguage,
+        options,
       );
       return results[0];
     }
   } catch (error) {
+    throwIfSignalCancelled(options?.signal);
     console.error('阿里云翻译错误:', error);
     throw new Error(error?.message || '翻译失败');
   }
@@ -103,7 +110,9 @@ async function batchTranslate(
   texts: string[],
   sourceLanguage: string,
   targetLanguage: string,
+  options?: TranslationRequestOptions,
 ): Promise<string[]> {
+  throwIfSignalCancelled(options?.signal);
   // 准备批量翻译的输入格式
   // 格式: { "1": "text1", "2": "text2", ... }
   const sourceTextObj: Record<string, string> = {};
@@ -131,11 +140,13 @@ async function batchTranslate(
   });
 
   try {
+    throwIfSignalCancelled(options?.signal);
     // 发起批量翻译请求
     const response = await client.getBatchTranslateWithOptions(
       request,
       runtime,
     );
+    throwIfSignalCancelled(options?.signal);
 
     // 处理返回结果
     if (response?.body?.code === 200 && response?.body?.translatedList) {
@@ -153,6 +164,7 @@ async function batchTranslate(
 
     throw new Error(response?.body?.message || '批量翻译请求返回错误');
   } catch (error) {
+    throwIfSignalCancelled(options?.signal);
     console.error('阿里云批量翻译错误:', error);
     throw error;
   }

--- a/main/service/azure.ts
+++ b/main/service/azure.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 interface AzureTranslateResponse {
   translations: {
@@ -20,8 +22,10 @@ const azureTranslator = async (
   },
   sourceLanguage?: string,
   targetLanguage?: string,
+  options?: TranslationRequestOptions,
 ): Promise<string | string[]> => {
   try {
+    throwIfSignalCancelled(options?.signal);
     const endpoint = 'https://api.cognitive.microsofttranslator.com';
     const route = '/translate';
 
@@ -51,8 +55,10 @@ const azureTranslator = async (
       data: requestBody,
       responseType: 'json',
       timeout: TRANSLATION_REQUEST_TIMEOUT,
+      signal: options?.signal,
     });
     console.log(response, 'response');
+    throwIfSignalCancelled(options?.signal);
 
     // 处理响应
     const results = response.data as AzureTranslateResponse[];
@@ -61,6 +67,7 @@ const azureTranslator = async (
     // 根据输入类型返回对应格式
     return Array.isArray(texts) ? translations : translations[0];
   } catch (error) {
+    throwIfSignalCancelled(options?.signal);
     console.log(error, 'error');
     if (axios.isAxiosError(error)) {
       const message = error.response?.data?.error?.message || error.message;

--- a/main/service/azureOpenai.ts
+++ b/main/service/azureOpenai.ts
@@ -1,5 +1,10 @@
 import { AzureOpenAI } from 'openai';
 import { TRANSLATION_JSON_SCHEMA } from '../translate/constants/schema';
+import {
+  TaskCancelledError,
+  throwIfSignalCancelled,
+} from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 type AzureOpenAIProvider = {
   apiUrl: string;
@@ -11,10 +16,14 @@ type AzureOpenAIProvider = {
 };
 
 export async function translateWithAzureOpenAI(
-  text: string[],
+  text: string | string[],
   provider: AzureOpenAIProvider,
+  _sourceLanguage?: string,
+  _targetLanguage?: string,
+  options?: TranslationRequestOptions,
 ) {
   try {
+    throwIfSignalCancelled(options?.signal);
     // 处理Azure OpenAI的endpoint URL
     const url = new URL(provider.apiUrl);
     const pathParts = url.pathname.split('/');
@@ -55,12 +64,16 @@ export async function translateWithAzureOpenAI(
       }
     }
 
-    const completion = await openai.chat.completions.create(requestParams);
+    const completion = await openai.chat.completions.create(requestParams, {
+      signal: options?.signal,
+    });
+    throwIfSignalCancelled(options?.signal);
 
     const result = completion?.choices?.[0]?.message?.content?.trim();
 
     return result;
   } catch (error) {
+    if (options?.signal?.aborted) throw new TaskCancelledError();
     console.error('Azure OpenAI translation error:', error);
     throw new Error(`Azure OpenAI translation failed: ${error.message}`);
   }

--- a/main/service/baidu.ts
+++ b/main/service/baidu.ts
@@ -2,13 +2,17 @@ import crypto from 'crypto';
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
 import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 export default async function baidu(
   query,
   proof,
   sourceLanguage,
   targetLanguage,
+  options?: TranslationRequestOptions,
 ) {
+  throwIfSignalCancelled(options?.signal);
   const { apiKey: appid, apiSecret: key } = proof || {};
   if (!appid || !key) {
     console.log('请先配置 API KEY 和 API SECRET');
@@ -43,8 +47,10 @@ export default async function baidu(
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       timeout: TRANSLATION_REQUEST_TIMEOUT,
+      signal: options?.signal,
     },
   );
+  throwIfSignalCancelled(options?.signal);
   if (!res?.data?.trans_result) {
     throw new Error(res?.data?.error_msg || '未知错误');
   }

--- a/main/service/bingFree.ts
+++ b/main/service/bingFree.ts
@@ -5,6 +5,8 @@ import {
   acquire,
   resolveRateLimitConfig,
 } from '../translate/utils/rateLimiter';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 /**
  * Bing（Edge 浏览器内置）免费翻译，无需 API Key。
@@ -27,14 +29,20 @@ const USER_AGENT =
 let cachedToken = '';
 let tokenFetchedAt = 0;
 
-async function getToken(force = false): Promise<string> {
+async function getToken(
+  force = false,
+  options?: TranslationRequestOptions,
+): Promise<string> {
   if (!force && cachedToken && Date.now() - tokenFetchedAt < TOKEN_TTL_MS) {
     return cachedToken;
   }
+  throwIfSignalCancelled(options?.signal);
   const res = await axios.get(AUTH_ENDPOINT, {
     timeout: TRANSLATION_REQUEST_TIMEOUT,
     headers: { 'User-Agent': USER_AGENT },
+    signal: options?.signal,
   });
+  throwIfSignalCancelled(options?.signal);
   if (!res.data || typeof res.data !== 'string') {
     throw new Error('Bing free translate failed (network): empty auth token');
   }
@@ -47,6 +55,7 @@ async function requestTranslate(
   texts: string[],
   to: string,
   token: string,
+  options?: TranslationRequestOptions,
 ): Promise<any[]> {
   const res = await axios.post(
     TRANSLATE_ENDPOINT,
@@ -59,8 +68,10 @@ async function requestTranslate(
         'Content-Type': 'application/json',
       },
       timeout: TRANSLATION_REQUEST_TIMEOUT,
+      signal: options?.signal,
     },
   );
+  throwIfSignalCancelled(options?.signal);
   return res.data;
 }
 
@@ -69,7 +80,9 @@ export default async function bingFree(
   proof: Record<string, any>,
   sourceLanguage: string,
   targetLanguage: string,
+  options?: TranslationRequestOptions,
 ): Promise<string | string[]> {
+  throwIfSignalCancelled(options?.signal);
   const list = Array.isArray(query) ? query : [query];
   const to = convertLanguageCode(targetLanguage, 'bing');
   if (!to) {
@@ -83,21 +96,23 @@ export default async function bingFree(
   const texts = list.map((t) => (t ?? '').slice(0, MAX_TEXT_LENGTH));
 
   const runOnce = async (forceToken: boolean): Promise<any[]> => {
-    const token = await getToken(forceToken);
-    await acquire(rateKey, rateCfg);
-    return requestTranslate(texts, to, token);
+    const token = await getToken(forceToken, options);
+    await acquire(rateKey, rateCfg, options?.signal);
+    return requestTranslate(texts, to, token, options);
   };
 
   let data: any[];
   try {
     data = await runOnce(false);
   } catch (error: any) {
+    throwIfSignalCancelled(options?.signal);
     const status = error?.response?.status;
     if (status === 401 || status === 403) {
       // token 失效，强制续期后重试一次
       try {
         data = await runOnce(true);
       } catch (retryError: any) {
+        throwIfSignalCancelled(options?.signal);
         throw new Error(
           `Bing free translate failed (network): ${retryError?.message || 'retry error'}`,
         );

--- a/main/service/deeplx.ts
+++ b/main/service/deeplx.ts
@@ -4,6 +4,8 @@ import {
   acquire,
   resolveRateLimitConfig,
 } from '../translate/utils/rateLimiter';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 /**
  * DeepLX 翻译（非官方 DeepL，需用户自建/自填端点）。
@@ -26,7 +28,9 @@ export default async function deeplx(
   proof: Record<string, any>,
   sourceLanguage?: string,
   targetLanguage?: string,
+  options?: TranslationRequestOptions,
 ): Promise<string | string[]> {
+  throwIfSignalCancelled(options?.signal);
   const { apiUrl } = proof || {};
   if (!apiUrl) {
     throw new Error('DeepLX endpoint not configured (network)');
@@ -44,12 +48,13 @@ export default async function deeplx(
 
   const translateOne = async (text: string): Promise<string> => {
     if (!text || !text.trim()) return text ?? '';
-    await acquire(rateKey, rateCfg);
+    await acquire(rateKey, rateCfg, options?.signal);
     const res = await axios.post(
       apiUrl,
       { text, source_lang, target_lang },
-      { timeout: TRANSLATION_REQUEST_TIMEOUT },
+      { timeout: TRANSLATION_REQUEST_TIMEOUT, signal: options?.signal },
     );
+    throwIfSignalCancelled(options?.signal);
     const data = res?.data || {};
     const out =
       typeof data.data === 'string'

--- a/main/service/doubao.ts
+++ b/main/service/doubao.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
 import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 const DOUBAO_API_URL = 'https://ark.cn-beijing.volces.com/api/v3/responses';
 const DEFAULT_MODEL = 'doubao-seed-translation-250915';
@@ -10,7 +12,9 @@ export default async function translate(
   proof: { apiKey?: string; modelName?: string },
   sourceLanguage: string,
   targetLanguage: string,
+  options?: TranslationRequestOptions,
 ) {
+  throwIfSignalCancelled(options?.signal);
   const { apiKey, modelName } = proof || {};
   if (!apiKey) {
     console.log('请先配置 API KEY');
@@ -30,6 +34,7 @@ export default async function translate(
 
   // 豆包翻译API每次只能翻译一条文本，需要循环调用
   for (const text of queryArray) {
+    throwIfSignalCancelled(options?.signal);
     const requestBody = {
       model: modelName || DEFAULT_MODEL,
       input: [
@@ -56,7 +61,9 @@ export default async function translate(
           Authorization: `Bearer ${apiKey}`,
         },
         timeout: TRANSLATION_REQUEST_TIMEOUT,
+        signal: options?.signal,
       });
+      throwIfSignalCancelled(options?.signal);
 
       // 解析响应
       const output = res?.data?.output;
@@ -68,6 +75,7 @@ export default async function translate(
       const translatedText = extractTranslation(output);
       results.push(translatedText);
     } catch (error) {
+      throwIfSignalCancelled(options?.signal);
       if (axios.isAxiosError(error)) {
         const errorMessage =
           error.response?.data?.error?.message ||

--- a/main/service/google.ts
+++ b/main/service/google.ts
@@ -1,13 +1,17 @@
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
 import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 export default async function google(
   query,
   proof,
   sourceLanguage,
   targetLanguage,
+  options?: TranslationRequestOptions,
 ) {
+  throwIfSignalCancelled(options?.signal);
   const { apiKey } = proof || {};
   if (!apiKey) {
     console.log('请先配置 Google Translate API Key');
@@ -45,8 +49,10 @@ export default async function google(
           'Content-Type': 'application/json',
         },
         timeout: TRANSLATION_REQUEST_TIMEOUT,
+        signal: options?.signal,
       },
     );
+    throwIfSignalCancelled(options?.signal);
 
     if (!response?.data?.data?.translations) {
       throw new Error(response?.data?.error?.message || '翻译失败');
@@ -62,6 +68,7 @@ export default async function google(
     }
     return translations.join('\n');
   } catch (error) {
+    throwIfSignalCancelled(options?.signal);
     console.log(error, 'google error');
     if (error.response) {
       // API 返回错误

--- a/main/service/googleFree.ts
+++ b/main/service/googleFree.ts
@@ -5,6 +5,8 @@ import {
   acquire,
   resolveRateLimitConfig,
 } from '../translate/utils/rateLimiter';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 /**
  * Google 免费翻译，无需 API Key。
@@ -23,10 +25,11 @@ async function translateOne(
   tl: string,
   rateKey: string,
   rateCfg: ReturnType<typeof resolveRateLimitConfig>,
+  options?: TranslationRequestOptions,
 ): Promise<string> {
   if (!text || !text.trim()) return text ?? '';
 
-  await acquire(rateKey, rateCfg);
+  await acquire(rateKey, rateCfg, options?.signal);
   const res = await axios.get(ENDPOINT, {
     params: {
       client: 'gtx',
@@ -37,7 +40,9 @@ async function translateOne(
     },
     headers: { 'User-Agent': USER_AGENT },
     timeout: TRANSLATION_REQUEST_TIMEOUT,
+    signal: options?.signal,
   });
+  throwIfSignalCancelled(options?.signal);
 
   const data = res.data;
   if (!Array.isArray(data) || !Array.isArray(data[0])) {
@@ -56,7 +61,9 @@ export default async function googleFree(
   proof: Record<string, any>,
   sourceLanguage: string,
   targetLanguage: string,
+  options?: TranslationRequestOptions,
 ): Promise<string | string[]> {
+  throwIfSignalCancelled(options?.signal);
   const list = Array.isArray(query) ? query : [query];
   const sl = convertLanguageCode(sourceLanguage, 'google') || 'auto';
   const tl = convertLanguageCode(targetLanguage, 'google');
@@ -71,8 +78,9 @@ export default async function googleFree(
   const results: string[] = [];
   for (const text of list) {
     try {
-      results.push(await translateOne(text, sl, tl, rateKey, rateCfg));
+      results.push(await translateOne(text, sl, tl, rateKey, rateCfg, options));
     } catch (error: any) {
+      throwIfSignalCancelled(options?.signal);
       throw new Error(
         `Google free translate failed (network): ${error?.message || 'request error'}`,
       );

--- a/main/service/niutrans.ts
+++ b/main/service/niutrans.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
 import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 const NIUTRANS_API = 'https://api.niutrans.com/NiuTransServer/translation';
 
@@ -16,7 +18,9 @@ export default async function niutrans(
   proof: { apiKey?: string },
   sourceLanguage: string,
   targetLanguage: string,
+  options?: TranslationRequestOptions,
 ): Promise<string | string[]> {
+  throwIfSignalCancelled(options?.signal);
   const { apiKey } = proof || {};
   if (!apiKey) {
     console.log('请先配置小牛翻译 API Key');
@@ -31,6 +35,7 @@ export default async function niutrans(
   }
 
   const translateOne = async (text: string): Promise<string> => {
+    throwIfSignalCancelled(options?.signal);
     const body = new URLSearchParams({
       from,
       to,
@@ -40,7 +45,9 @@ export default async function niutrans(
     const res = await axios.post(NIUTRANS_API, body.toString(), {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       timeout: TRANSLATION_REQUEST_TIMEOUT,
+      signal: options?.signal,
     });
+    throwIfSignalCancelled(options?.signal);
     const data = res?.data || {};
     if (data.error_code) {
       throw new Error(

--- a/main/service/ollama.ts
+++ b/main/service/ollama.ts
@@ -1,6 +1,11 @@
 import axios from 'axios';
 import { TRANSLATION_JSON_SCHEMA } from '../translate/constants/schema';
 import { OLLAMA_REQUEST_TIMEOUT } from '../translate/constants';
+import {
+  TaskCancelledError,
+  throwIfSignalCancelled,
+} from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 interface OllamaConfig {
   apiUrl: string;
@@ -48,14 +53,19 @@ function isSchemaFormatUnsupportedError(error: any): boolean {
 }
 
 export default async function translateWithOllama(
-  text: string,
+  text: string | string[],
   config: OllamaConfig,
+  _sourceLanguage?: string,
+  _targetLanguage?: string,
+  options?: TranslationRequestOptions,
 ) {
   const { apiUrl, modelName, systemPrompt } = config;
   const url = apiUrl.replace('generate', 'chat'); // 兼容旧版本的ollama
   const structuredOutputMode = getStructuredOutputMode(config);
+  const userPrompt = Array.isArray(text) ? text.join('\n') : text;
 
   try {
+    throwIfSignalCancelled(options?.signal);
     // 为JSON模式增强system prompt
     let enhancedSystemPrompt = systemPrompt;
 
@@ -68,7 +78,7 @@ export default async function translateWithOllama(
       model: modelName,
       messages: [
         { role: 'system', content: enhancedSystemPrompt },
-        { role: 'user', content: text },
+        { role: 'user', content: userPrompt },
       ],
       stream: false,
     };
@@ -79,12 +89,16 @@ export default async function translateWithOllama(
     }
 
     const postOllama = (body: Record<string, any>) =>
-      axios.post(`${url}`, body, { timeout: OLLAMA_REQUEST_TIMEOUT });
+      axios.post(`${url}`, body, {
+        timeout: OLLAMA_REQUEST_TIMEOUT,
+        signal: options?.signal,
+      });
 
     let response;
     try {
       response = await postOllama(requestBody);
     } catch (error) {
+      throwIfSignalCancelled(options?.signal);
       if (
         structuredOutputMode === 'json_schema' &&
         isSchemaFormatUnsupportedError(error)
@@ -99,6 +113,7 @@ export default async function translateWithOllama(
     }
 
     if (response.data && response.data.message) {
+      throwIfSignalCancelled(options?.signal);
       return response.data.message?.content?.trim();
     } else {
       throw new Error(
@@ -106,6 +121,7 @@ export default async function translateWithOllama(
       );
     }
   } catch (error) {
+    if (options?.signal?.aborted) throw new TaskCancelledError();
     throw error;
   }
 }

--- a/main/service/openai.ts
+++ b/main/service/openai.ts
@@ -6,6 +6,11 @@ import {
 } from '../translate/constants/schema';
 import { ParameterProcessor } from '../helpers/parameterProcessor';
 import { ExtendedProvider } from '../../types/provider';
+import {
+  TaskCancelledError,
+  throwIfSignalCancelled,
+} from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 type OpenAIProvider = {
   apiUrl: string;
@@ -236,7 +241,7 @@ function getCustomHeaders(provider: OpenAIProvider): Record<string, string> {
 /**
  * 创建基础请求参数 (Enhanced with Parameter Processor)
  */
-function createBaseParams(text: string[], provider: OpenAIProvider) {
+function createBaseParams(text: string | string[], provider: OpenAIProvider) {
   const sysPrompt =
     provider.systemPrompt || 'You are a professional subtitle translation tool';
   const userPrompt = Array.isArray(text) ? text.join('\n') : text;
@@ -261,42 +266,59 @@ function createBaseParams(text: string[], provider: OpenAIProvider) {
 async function callWithJsonSchema(
   openai: OpenAI,
   baseParams: any,
+  options?: TranslationRequestOptions,
 ): Promise<string | undefined> {
   console.log('Using JSON Schema API with zod schema');
   try {
-    const completion = await openai.beta.chat.completions.parse({
-      ...baseParams,
-      response_format: zodResponseFormat(
-        TranslationResultSchema,
-        'translation',
-      ),
-    });
+    throwIfSignalCancelled(options?.signal);
+    const completion = await openai.beta.chat.completions.parse(
+      {
+        ...baseParams,
+        response_format: zodResponseFormat(
+          TranslationResultSchema,
+          'translation',
+        ),
+      },
+      { signal: options?.signal },
+    );
 
     console.log('JSON Schema completion:', completion?.choices);
+    throwIfSignalCancelled(options?.signal);
     const parsed = completion?.choices?.[0]?.message?.parsed;
     if (parsed && typeof parsed === 'object') {
       return JSON.stringify(parsed);
     }
     return parsed ? String(parsed) : undefined;
   } catch (parseError) {
+    throwIfSignalCancelled(options?.signal);
     console.warn(
       'JSON Schema parse failed, falling back to json_object API:',
       parseError,
     );
     // 回退到json_object模式
     try {
-      const fallbackCompletion = (await openai.chat.completions.create({
-        ...baseParams,
-        response_format: { type: 'json_object' },
-      })) as OpenAI.Chat.Completions.ChatCompletion;
+      const fallbackCompletion = (await openai.chat.completions.create(
+        {
+          ...baseParams,
+          response_format: { type: 'json_object' },
+        },
+        { signal: options?.signal },
+      )) as OpenAI.Chat.Completions.ChatCompletion;
+      throwIfSignalCancelled(options?.signal);
       return fallbackCompletion?.choices?.[0]?.message?.content?.trim();
     } catch (fallbackError) {
+      throwIfSignalCancelled(options?.signal);
       if (isStructuredOutputUnsupportedError(fallbackError)) {
         console.warn(
           'json_object response format failed, retrying without structured output:',
           fallbackError,
         );
-        return await callWithStandardAPI(openai, baseParams, 'disabled');
+        return await callWithStandardAPI(
+          openai,
+          baseParams,
+          'disabled',
+          options,
+        );
       }
       throw fallbackError;
     }
@@ -310,6 +332,7 @@ async function callWithStandardAPI(
   openai: OpenAI,
   baseParams: any,
   structuredOutputMode: 'disabled' | 'json_object' | 'json_schema',
+  options?: TranslationRequestOptions,
 ): Promise<string | undefined> {
   console.log(
     `Using standard OpenAI-compatible API with mode: ${structuredOutputMode}`,
@@ -329,10 +352,12 @@ async function callWithStandardAPI(
 
   let completion: OpenAI.Chat.Completions.ChatCompletion;
   try {
-    completion = (await openai.chat.completions.create(
-      requestParams,
-    )) as OpenAI.Chat.Completions.ChatCompletion;
+    throwIfSignalCancelled(options?.signal);
+    completion = (await openai.chat.completions.create(requestParams, {
+      signal: options?.signal,
+    })) as OpenAI.Chat.Completions.ChatCompletion;
   } catch (error) {
+    throwIfSignalCancelled(options?.signal);
     if (
       structuredOutputMode === 'json_object' &&
       isStructuredOutputUnsupportedError(error)
@@ -341,14 +366,15 @@ async function callWithStandardAPI(
         'json_object response format failed, retrying without structured output:',
         error,
       );
-      completion = (await openai.chat.completions.create(
-        baseParams,
-      )) as OpenAI.Chat.Completions.ChatCompletion;
+      completion = (await openai.chat.completions.create(baseParams, {
+        signal: options?.signal,
+      })) as OpenAI.Chat.Completions.ChatCompletion;
     } else {
       throw error;
     }
   }
   console.log('Standard completion:', completion?.choices);
+  throwIfSignalCancelled(options?.signal);
   return completion?.choices?.[0]?.message?.content?.trim();
 }
 
@@ -356,8 +382,11 @@ async function callWithStandardAPI(
  * 主要的翻译函数 (Enhanced with Parameter Processor)
  */
 export async function translateWithOpenAI(
-  text: string[],
+  text: string | string[],
   provider: OpenAIProvider,
+  _sourceLanguage?: string,
+  _targetLanguage?: string,
+  options?: TranslationRequestOptions,
 ): Promise<string | undefined> {
   if (!provider.apiKey) {
     throw new Error('OpenAI API key is required');
@@ -365,6 +394,7 @@ export async function translateWithOpenAI(
   const normalizedApiUrl = normalizeOpenAIBaseURL(provider.apiUrl);
   console.log('translateWithOpenAI', text, provider);
   try {
+    throwIfSignalCancelled(options?.signal);
     console.log('Provider config:', {
       id: provider.id,
       apiUrl: normalizedApiUrl,
@@ -420,15 +450,17 @@ export async function translateWithOpenAI(
     const structuredOutputMode = getStructuredOutputMode(provider);
 
     if (structuredOutputMode === 'json_schema') {
-      return await callWithJsonSchema(openai, baseParams);
+      return await callWithJsonSchema(openai, baseParams, options);
     } else {
       return await callWithStandardAPI(
         openai,
         baseParams,
         structuredOutputMode,
+        options,
       );
     }
   } catch (error) {
+    if (options?.signal?.aborted) throw new TaskCancelledError();
     console.error('OpenAI translation error:', error);
     throw new Error(
       `OpenAI translation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/main/service/tencent.ts
+++ b/main/service/tencent.ts
@@ -2,6 +2,8 @@ import crypto from 'crypto';
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
 import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 const HOST = 'tmt.tencentcloudapi.com';
 const ENDPOINT = `https://${HOST}`;
@@ -87,7 +89,9 @@ export default async function tencent(
   proof: { apiKey?: string; apiSecret?: string; region?: string },
   sourceLanguage: string,
   targetLanguage: string,
+  options?: TranslationRequestOptions,
 ): Promise<string | string[]> {
+  throwIfSignalCancelled(options?.signal);
   const {
     apiKey: secretId,
     apiSecret: secretKey,
@@ -106,6 +110,7 @@ export default async function tencent(
   }
 
   const translateOne = async (text: string): Promise<string> => {
+    throwIfSignalCancelled(options?.signal);
     const payload = JSON.stringify({
       SourceText: text,
       Source: source,
@@ -116,7 +121,9 @@ export default async function tencent(
     const res = await axios.post(ENDPOINT, payload, {
       headers,
       timeout: TRANSLATION_REQUEST_TIMEOUT,
+      signal: options?.signal,
     });
+    throwIfSignalCancelled(options?.signal);
     const response = res?.data?.Response;
     if (!response || response.Error) {
       throw new Error(

--- a/main/service/volc.ts
+++ b/main/service/volc.ts
@@ -1,5 +1,7 @@
 import { Service } from '@volcengine/openapi';
 import { convertLanguageCode } from '../helpers/utils';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 let service;
 let fetchApi;
@@ -9,7 +11,9 @@ export default async function translate(
   proof,
   sourceLanguage,
   targetLanguage,
+  options?: TranslationRequestOptions,
 ) {
+  throwIfSignalCancelled(options?.signal);
   const { apiKey: accessKeyId, apiSecret: secretKey } = proof || {};
   if (!accessKeyId || !secretKey) {
     console.log('请先配置 API KEY 和 API SECRET');
@@ -36,12 +40,15 @@ export default async function translate(
     });
   }
   const postBody = {
-    SourceLanguage: formatSourceLanguage == 'auto' ? undefined : formatSourceLanguage,
+    SourceLanguage:
+      formatSourceLanguage == 'auto' ? undefined : formatSourceLanguage,
     TargetLanguage: formatTargetLanguage,
     TextList: Array.isArray(query) ? query : [query],
   };
   try {
+    throwIfSignalCancelled(options?.signal);
     const res = await fetchApi(postBody, {});
+    throwIfSignalCancelled(options?.signal);
     if (!res?.TranslationList?.[0]?.Translation) {
       throw new Error(res?.ResponseMetadata?.Error?.Code || '未知错误');
     }
@@ -52,6 +59,7 @@ export default async function translate(
     }
     return res.TranslationList[0].Translation;
   } catch (error) {
+    throwIfSignalCancelled(options?.signal);
     throw new Error(error?.message || '未知错误');
   }
 }

--- a/main/service/xunfei.ts
+++ b/main/service/xunfei.ts
@@ -2,6 +2,8 @@ import crypto from 'crypto';
 import axios from 'axios';
 import { convertLanguageCode } from '../helpers/utils';
 import { TRANSLATION_REQUEST_TIMEOUT } from '../translate/constants';
+import { throwIfSignalCancelled } from '../helpers/taskContext';
+import type { TranslationRequestOptions } from '../translate/types';
 
 const HOST = 'ntrans.xfyun.cn';
 const REQUEST_LINE = 'POST /v2/ots HTTP/1.1';
@@ -18,7 +20,9 @@ export default async function xunfei(
   proof: { appId?: string; apiKey?: string; apiSecret?: string },
   sourceLanguage: string,
   targetLanguage: string,
+  options?: TranslationRequestOptions,
 ): Promise<string | string[]> {
+  throwIfSignalCancelled(options?.signal);
   const { appId, apiKey, apiSecret } = proof || {};
   if (!appId || !apiKey || !apiSecret) {
     console.log('请先配置讯飞 APPID、APIKey 和 APISecret');
@@ -33,6 +37,7 @@ export default async function xunfei(
   }
 
   const translateOne = async (text: string): Promise<string> => {
+    throwIfSignalCancelled(options?.signal);
     const body = JSON.stringify({
       common: { app_id: appId },
       business: { from, to },
@@ -59,7 +64,9 @@ export default async function xunfei(
         Authorization: authorization,
       },
       timeout: TRANSLATION_REQUEST_TIMEOUT,
+      signal: options?.signal,
     });
+    throwIfSignalCancelled(options?.signal);
 
     const data = res?.data;
     if (!data || data.code !== 0) {

--- a/main/translate/services/ai.ts
+++ b/main/translate/services/ai.ts
@@ -7,6 +7,8 @@ import { isConfigurationError } from '../utils/error';
 import {
   throwIfTaskCancelled,
   isTaskCancelledError,
+  throwIfSignalCancelled,
+  waitForTaskDelay,
 } from '../../helpers/taskContext';
 import { parseAITranslationResponse } from '../utils/aiResponseParser';
 import {
@@ -132,9 +134,14 @@ export async function handleAIBatchTranslation(
           translationConfig,
           sourceLanguage,
           targetLanguage,
+          { signal: config.signal },
         );
-        logMessage(`AI response: \n ${responseOrigin}`, 'info');
-        const parsedContent = parseAITranslationResponse(responseOrigin);
+        throwIfSignalCancelled(config.signal);
+        const responseText = Array.isArray(responseOrigin)
+          ? responseOrigin.join('\n')
+          : responseOrigin;
+        logMessage(`AI response: \n ${responseText}`, 'info');
+        const parsedContent = parseAITranslationResponse(responseText);
 
         // 检查解析结果是否有效
         if (parsedContent) {
@@ -186,6 +193,7 @@ export async function handleAIBatchTranslation(
         }
       } catch (error) {
         if (isTaskCancelledError(error)) throw error;
+        throwIfSignalCancelled(config.signal);
         // 检查是否是配置错误，如果是则直接抛出，不进行重试
         if (isConfigurationError(error)) {
           throw new Error(
@@ -200,9 +208,7 @@ export async function handleAIBatchTranslation(
             'warning',
           );
           // 添加短暂延迟，避免频繁重试
-          await new Promise((resolve) =>
-            setTimeout(resolve, 1000 * retryCount),
-          );
+          await waitForTaskDelay(1000 * retryCount, config.signal);
         } else {
           logMessage(
             `批次 ${currentBatchIndex}/${totalBatches} 翻译失败，已达到最大重试次数 ${maxRetries}，跳过该批次: ${error.message}`,

--- a/main/translate/services/api.ts
+++ b/main/translate/services/api.ts
@@ -5,6 +5,8 @@ import { isConfigurationError } from '../utils/error';
 import {
   throwIfTaskCancelled,
   isTaskCancelledError,
+  throwIfSignalCancelled,
+  waitForTaskDelay,
 } from '../../helpers/taskContext';
 import {
   createTranslationBatches,
@@ -63,7 +65,9 @@ export async function handleAPIBatchTranslation(
           provider,
           sourceLanguage,
           targetLanguage,
+          { signal: config.signal },
         );
+        throwIfSignalCancelled(config.signal);
 
         const translatedLines = Array.isArray(translatedContent)
           ? translatedContent
@@ -85,6 +89,7 @@ export async function handleAPIBatchTranslation(
         batchSuccess = true;
       } catch (error) {
         if (isTaskCancelledError(error)) throw error;
+        throwIfSignalCancelled(config.signal);
         // 检查是否是配置错误，如果是则直接抛出，不进行重试
         if (isConfigurationError(error)) {
           throw new Error(
@@ -99,9 +104,7 @@ export async function handleAPIBatchTranslation(
             'warning',
           );
           // 添加短暂延迟，避免频繁重试
-          await new Promise((resolve) =>
-            setTimeout(resolve, 1000 * retryCount),
-          );
+          await waitForTaskDelay(1000 * retryCount, config.signal);
         } else {
           logMessage(
             `批次 ${currentBatchIndex}/${totalBatches} 翻译失败，已达到最大重试次数 ${maxRetries}，跳过该批次: ${error.message}`,

--- a/main/translate/services/fallback.ts
+++ b/main/translate/services/fallback.ts
@@ -5,6 +5,11 @@ import {
   googleFreeTranslator,
   deeplxTranslator,
 } from '../../service';
+import {
+  isTaskCancelledError,
+  throwIfSignalCancelled,
+} from '../../helpers/taskContext';
+import type { TranslationRequestOptions } from '../types';
 
 /**
  * 多源失败自动回退编排。
@@ -51,12 +56,15 @@ export function createFallbackTranslator(
     proof: any,
     sourceLanguage: string,
     targetLanguage: string,
+    options?: TranslationRequestOptions,
   ): Promise<any> {
+    throwIfSignalCancelled(options?.signal);
     const list = Array.isArray(query) ? query : [query];
     const chain = parseChain(proof?.fallbackChain, defaultChain);
     const errors: string[] = [];
 
     for (const sourceId of chain) {
+      throwIfSignalCancelled(options?.signal);
       if (sourceId === 'autoFree') continue; // 防止递归
       const translator = SOURCE_MAP[sourceId];
       if (!translator) {
@@ -78,7 +86,9 @@ export function createFallbackTranslator(
           { ...proof, id: sourceId },
           sourceLanguage,
           targetLanguage,
+          options,
         );
+        throwIfSignalCancelled(options?.signal);
         const arr = Array.isArray(res) ? res : [res];
         // 校验：长度对齐且非全空
         const aligned = arr.length === list.length;
@@ -91,6 +101,8 @@ export function createFallbackTranslator(
         }
         errors.push(`${sourceId}: invalid result (aligned=${aligned})`);
       } catch (error: any) {
+        if (isTaskCancelledError(error)) throw error;
+        throwIfSignalCancelled(options?.signal);
         const msg = error?.message || 'error';
         errors.push(`${sourceId}: ${msg}`);
         logMessage(`autoFree source ${sourceId} failed: ${msg}`, 'warning');

--- a/main/translate/services/translationProvider.ts
+++ b/main/translate/services/translationProvider.ts
@@ -26,6 +26,7 @@ import {
   xunfeiTranslator,
 } from '../../service';
 import { DEFAULT_BATCH_SIZE } from '../constants';
+import { getTaskSignal } from '../../helpers/taskContext';
 
 /** autoFree 默认回退链：Bing 免费 → Google 免费 → DeepLX */
 export const DEFAULT_FREE_FALLBACK_CHAIN = ['bingFree', 'googleFree', 'deeplx'];
@@ -69,6 +70,7 @@ export async function translateWithProvider(
     sourceLanguage,
     targetLanguage,
     translator,
+    signal: getTaskSignal(),
   };
 
   logMessage(

--- a/main/translate/types/index.ts
+++ b/main/translate/types/index.ts
@@ -16,14 +16,20 @@ export interface TranslationConfig {
   targetLanguage: string;
   provider: Provider;
   translator: TranslatorFunction;
+  signal?: AbortSignal;
 }
 
 export type TranslatorFunction = (
-  text: string[],
+  text: string | string[],
   config: any,
   from: string,
   to: string,
-) => Promise<string>;
+  options?: TranslationRequestOptions,
+) => Promise<string | string[]>;
+
+export interface TranslationRequestOptions {
+  signal?: AbortSignal;
+}
 
 export interface Provider {
   type: string;

--- a/main/translate/utils/batchConcurrency.ts
+++ b/main/translate/utils/batchConcurrency.ts
@@ -1,5 +1,8 @@
 import type { Subtitle, TranslationResult } from '../types';
-import { throwIfTaskCancelled } from '../../helpers/taskContext';
+import {
+  throwIfTaskCancelled,
+  waitForTaskDelay,
+} from '../../helpers/taskContext';
 import { logMessage } from '../../helpers/storeManager';
 
 export type TranslationBatch = {
@@ -90,7 +93,7 @@ export async function runTranslationBatchesInOrder({
         `批次 ${displayIndex} 等待 ${(waitMs / 1000).toFixed(2)}s (请求间隔)`,
         'info',
       );
-      await new Promise((resolve) => setTimeout(resolve, waitMs));
+      await waitForTaskDelay(waitMs);
     }
   };
 

--- a/main/translate/utils/rateLimiter.ts
+++ b/main/translate/utils/rateLimiter.ts
@@ -45,9 +45,9 @@ export async function acquire(
 
   // 等待前一个同 key 的请求完成排队
   await prev;
-  throwIfSignalCancelled(signal);
 
   try {
+    throwIfSignalCancelled(signal);
     const { minIntervalMs = 0, windowMs = 0, maxInWindow = 0 } = cfg;
 
     // 1) 最小间隔

--- a/main/translate/utils/rateLimiter.ts
+++ b/main/translate/utils/rateLimiter.ts
@@ -8,6 +8,11 @@
  * 通过 per-key 的异步互斥串行化，避免并发任务击穿限速。
  */
 
+import {
+  throwIfSignalCancelled,
+  waitForTaskDelay,
+} from '../../helpers/taskContext';
+
 export interface RateLimitConfig {
   /** 相邻请求最小间隔（毫秒），<=0 表示不限制 */
   minIntervalMs?: number;
@@ -22,10 +27,6 @@ const windowHits: Record<string, number[]> = {};
 /** per-key 互斥链，保证同一 key 的 acquire 串行执行 */
 const locks: Record<string, Promise<void>> = {};
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
-}
-
 /**
  * 申请一次放行额度，必要时 await 到允许发起请求的时刻。
  * 调用方应在真正发起网络请求前 await 本函数。
@@ -33,7 +34,9 @@ function sleep(ms: number): Promise<void> {
 export async function acquire(
   key: string,
   cfg: RateLimitConfig = {},
+  signal?: AbortSignal,
 ): Promise<void> {
+  throwIfSignalCancelled(signal);
   const prev = locks[key] ?? Promise.resolve();
   let release!: () => void;
   locks[key] = new Promise<void>((resolve) => {
@@ -42,6 +45,7 @@ export async function acquire(
 
   // 等待前一个同 key 的请求完成排队
   await prev;
+  throwIfSignalCancelled(signal);
 
   try {
     const { minIntervalMs = 0, windowMs = 0, maxInWindow = 0 } = cfg;
@@ -49,7 +53,7 @@ export async function acquire(
     // 1) 最小间隔
     if (minIntervalMs > 0) {
       const wait = (lastCallAt[key] ?? 0) + minIntervalMs - Date.now();
-      if (wait > 0) await sleep(wait);
+      if (wait > 0) await waitForTaskDelay(wait, signal);
     }
 
     // 2) 滑动窗口
@@ -58,7 +62,7 @@ export async function acquire(
       hits = hits.filter((t) => t > Date.now() - windowMs);
       while (hits.length >= maxInWindow) {
         const waitFor = hits[0] + windowMs - Date.now();
-        if (waitFor > 0) await sleep(waitFor);
+        if (waitFor > 0) await waitForTaskDelay(waitFor, signal);
         hits = hits.filter((t) => t > Date.now() - windowMs);
       }
       hits.push(Date.now());
@@ -76,8 +80,9 @@ export async function withRateLimit<T>(
   key: string,
   cfg: RateLimitConfig,
   fn: () => Promise<T>,
+  signal?: AbortSignal,
 ): Promise<T> {
-  await acquire(key, cfg);
+  await acquire(key, cfg, signal);
   return fn();
 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:longgap": "tsc scripts/longgap/run.ts --outDir node_modules/.cache/longgap --module commonjs --moduleResolution node --target es2019 --esModuleInterop --skipLibCheck --resolveJsonModule && node node_modules/.cache/longgap/scripts/longgap/run.js",
     "test:longgap:outcomes": "tsc scripts/longgap/run-outcomes.ts --outDir node_modules/.cache/longgap --module commonjs --moduleResolution node --target es2019 --esModuleInterop --skipLibCheck --resolveJsonModule && node node_modules/.cache/longgap/scripts/longgap/run-outcomes.js",
     "sync:addon": "bash scripts/sync-gitcode.sh --target addon",
-    "sync:engine": "bash scripts/sync-gitcode.sh --target engine"
+    "sync:engine": "bash scripts/sync-gitcode.sh --target engine",
+    "test:translation-cancel": "tsc scripts/test-translation-cancel.ts --outDir node_modules/.cache/translation-cancel-tests --module commonjs --moduleResolution node --target es2019 --esModuleInterop --skipLibCheck --resolveJsonModule && node node_modules/.cache/translation-cancel-tests/scripts/test-translation-cancel.js"
   },
   "dependencies": {
     "@alicloud/alimt20181012": "^1.3.0",

--- a/scripts/test-translation-cancel.ts
+++ b/scripts/test-translation-cancel.ts
@@ -1,0 +1,113 @@
+/// <reference path="./test-globals.d.ts" />
+
+import axios from 'axios';
+import translateWithOllama from '../main/service/ollama';
+import {
+  isTaskCancelledError,
+  runWithTaskContext,
+  waitForTaskDelay,
+} from '../main/helpers/taskContext';
+
+let passed = 0;
+let failed = 0;
+
+function ok(value: unknown, name: string): void {
+  if (value) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`x ${name}`);
+  }
+}
+
+async function expectTaskCancelled(
+  fn: () => Promise<unknown>,
+  name: string,
+): Promise<void> {
+  try {
+    await fn();
+    failed++;
+    console.error(`x ${name}\n    expected TaskCancelledError`);
+  } catch (error) {
+    ok(isTaskCancelledError(error), name);
+  }
+}
+
+async function testAbortableDelay(): Promise<void> {
+  const controller = new AbortController();
+  const startedAt = Date.now();
+  setTimeout(() => controller.abort(), 20);
+
+  await expectTaskCancelled(
+    () =>
+      runWithTaskContext({ signal: controller.signal }, () =>
+        waitForTaskDelay(5_000),
+      ),
+    'waitForTaskDelay rejects when task signal aborts',
+  );
+
+  ok(
+    Date.now() - startedAt < 1_000,
+    'waitForTaskDelay does not wait for the full timeout after abort',
+  );
+}
+
+async function testOllamaAbortSignal(): Promise<void> {
+  const originalPost = axios.post;
+  const controller = new AbortController();
+  let observedSignal: AbortSignal | undefined;
+
+  (axios as any).post = (_url: string, _body: unknown, config: any) => {
+    observedSignal = config?.signal;
+    return new Promise((_resolve, reject) => {
+      observedSignal?.addEventListener(
+        'abort',
+        () => reject(new Error('axios request aborted')),
+        { once: true },
+      );
+    });
+  };
+
+  try {
+    setTimeout(() => controller.abort(), 20);
+
+    await expectTaskCancelled(
+      () =>
+        translateWithOllama(
+          '{"1":"hello"}',
+          {
+            apiUrl: 'http://localhost:11434/api/chat',
+            modelName: 'llama3.1',
+            prompt: '',
+            systemPrompt: 'Translate JSON',
+          },
+          'en',
+          'zh',
+          { signal: controller.signal },
+        ),
+      'translateWithOllama normalizes aborted axios requests',
+    );
+
+    ok(
+      observedSignal === controller.signal,
+      'translateWithOllama passes AbortSignal to axios',
+    );
+  } finally {
+    axios.post = originalPost;
+  }
+}
+
+async function main(): Promise<void> {
+  await testAbortableDelay();
+  await testOllamaAbortSignal();
+
+  console.log(`\ntranslation cancel tests: ${passed} passed, ${failed} failed`);
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/test-translation-cancel.ts
+++ b/scripts/test-translation-cancel.ts
@@ -7,6 +7,7 @@ import {
   runWithTaskContext,
   waitForTaskDelay,
 } from '../main/helpers/taskContext';
+import { acquire } from '../main/translate/utils/rateLimiter';
 
 let passed = 0;
 let failed = 0;
@@ -97,9 +98,38 @@ async function testOllamaAbortSignal(): Promise<void> {
   }
 }
 
+async function testRateLimiterQueuedAbortReleasesLock(): Promise<void> {
+  const key = `translation-cancel-test-${Date.now()}`;
+  await acquire(key);
+
+  const holdingAcquire = acquire(key, { minIntervalMs: 80 });
+  const controller = new AbortController();
+  const queuedAcquire = acquire(key, {}, controller.signal);
+  setTimeout(() => controller.abort(), 10);
+
+  await holdingAcquire;
+  await expectTaskCancelled(
+    () => queuedAcquire,
+    'rateLimiter acquire rejects a queued aborted request',
+  );
+
+  const nextAcquire = await Promise.race([
+    acquire(key),
+    new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), 200),
+    ),
+  ]);
+
+  ok(
+    nextAcquire !== 'timeout',
+    'rateLimiter releases lock after queued abort',
+  );
+}
+
 async function main(): Promise<void> {
   await testAbortableDelay();
   await testOllamaAbortSignal();
+  await testRateLimiterQueuedAbortReleasesLock();
 
   console.log(`\ntranslation cancel tests: ${passed} passed, ${failed} failed`);
   if (failed > 0) {


### PR DESCRIPTION
## 摘要
- 将当前任务的 `AbortSignal` 贯穿到翻译 provider 配置和 translator 调用链。
- 为 Ollama、OpenAI 兼容接口、Azure OpenAI 以及多个 axios 翻译源接入请求取消，停止按钮可以中止正在进行的翻译请求。
- 让重试等待、请求间隔等待、免费源限速等待、fallback 翻译和批量校对重试都能响应任务取消。
- rebase 到最新 `main`，保留已合入的 AI JSON 解析增强和 Ollama structured output fallback。
- 新增取消回归测试，覆盖可中止的任务等待和 Ollama 请求 signal 传递。

## 验证
- `npm run test:translation-cancel`
- `npm run test:translate-parser`
- `git diff --check`

Closes #351