### PR TITLE
fix: 为 TXT 校对入口增加不可用提示

### DIFF
--- a/main/helpers/fileProcessor.ts
+++ b/main/helpers/fileProcessor.ts
@@ -24,6 +24,7 @@ import {
   isSupportedSubtitleFormat,
   SubtitleFormat,
 } from './subtitleFormats';
+import { writeProofreadDataFromFiles } from './proofreadData';
 import {
   throwIfTaskCancelled,
   isTaskCancelled,
@@ -467,6 +468,29 @@ export async function processFile(
       getDesiredChineseScript(sourceLanguage)
     ) {
       await stripSourceSubtitlePunctuation(file.srtFile, fileName);
+    }
+
+    if (file.srtFile && fs.existsSync(file.srtFile)) {
+      const proofreadDataFile = await writeProofreadDataFromFiles({
+        file,
+        sourceFile: file.srtFile,
+        targetFile:
+          shouldTranslateSubtitle && translateProvider !== '-1'
+            ? file.tempTranslatedSrtFile || file.translatedSrtFile
+            : undefined,
+        finalTargetFile:
+          shouldTranslateSubtitle && translateProvider !== '-1'
+            ? file.translatedSrtFile
+            : undefined,
+        sourceLanguage,
+        targetLanguage,
+        translateContent: formData?.translateContent,
+        outputFormat: formData?.subtitleOutputFormat,
+      });
+      if (proofreadDataFile) {
+        file.proofreadDataFile = proofreadDataFile;
+        event.sender.send('taskFileChange', file);
+      }
     }
 
     // 将交付字幕转换为用户选择的输出格式（内部流程始终为 SRT，此处仅转换最终交付物）

--- a/main/helpers/ipcHandlers.ts
+++ b/main/helpers/ipcHandlers.ts
@@ -15,6 +15,11 @@ import {
   serializeCue,
   convertSubtitleContent,
 } from './subtitleFormats';
+import {
+  proofreadDataToSubtitleRows,
+  readProofreadDataFile,
+  updateProofreadDataFromSubtitles,
+} from './proofreadData';
 
 // 定义支持的文件扩展名常量
 export const MEDIA_EXTENSIONS = [
@@ -147,6 +152,71 @@ async function getMediaFilesFromDirectory(
   return files;
 }
 
+function buildSubtitleFileContent(
+  filePath: string,
+  subtitles: any[],
+  contentType = 'source',
+): string {
+  const format = detectSubtitleFormat(filePath);
+  const buildText = (subtitle): string => {
+    if (contentType === 'source') {
+      return subtitle.sourceContent ?? '';
+    }
+    const template =
+      CONTENT_TEMPLATES[contentType] || CONTENT_TEMPLATES.onlyTranslate;
+    return renderTemplate(template, {
+      sourceContent: subtitle.sourceContent ?? '',
+      targetContent: subtitle.targetContent ?? '',
+    }).replace(/\n+$/, '');
+  };
+
+  return (
+    getSubtitleFileHeader(format) +
+    subtitles
+      .map((subtitle) => {
+        const { startMs, endMs } = parseStartEndTime(subtitle.startEndTime);
+        return serializeCue(
+          {
+            id: subtitle.id,
+            startMs,
+            endMs,
+            text: buildText(subtitle),
+          },
+          format,
+        );
+      })
+      .join('')
+  );
+}
+
+async function backupSubtitleFile(filePath: string): Promise<void> {
+  try {
+    if (fs.existsSync(filePath)) {
+      const backupPath = path.join(
+        ensureTempDir(),
+        `subtitle-backup-${getMd5(filePath)}${path.extname(filePath)}.bak`,
+      );
+      await fs.promises.copyFile(filePath, backupPath);
+    }
+  } catch (backupError) {
+    logMessage(
+      `备份字幕文件失败（继续保存）: ${backupError.message}`,
+      'warning',
+    );
+  }
+}
+
+async function writeSubtitleFile(
+  filePath: string,
+  subtitles: any[],
+  contentType = 'source',
+): Promise<void> {
+  const content = buildSubtitleFileContent(filePath, subtitles, contentType);
+  await backupSubtitleFile(filePath);
+  await fs.promises.writeFile(filePath, content, 'utf-8');
+  logMessage(`保存字幕文件成功: ${filePath}`, 'info');
+}
+
 export function setupIpcHandlers(mainWindow: BrowserWindow) {
   ipcMain.on('message', async (event, arg) => {
     event.reply('message', `${arg} World!`);
@@ -267,6 +337,20 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
     }
   });
 
+  ipcMain.handle('readProofreadDataFile', async (event, { filePath }) => {
+    try {
+      if (!filePath || !fs.existsSync(filePath)) {
+        logMessage(`读取校对中间态失败: 文件不存在 ${filePath}`, 'error');
+        return [];
+      }
+      const proofreadData = await readProofreadDataFile(filePath);
+      return proofreadDataToSubtitleRows(proofreadData);
+    } catch (error) {
+      logMessage(`读取校对中间态错误: ${error.message}`, 'error');
+      return [];
+    }
+  });
+
   // 读取任意字幕文件并转换为 WebVTT 文本（供播放器内嵌字幕轨道使用）
   ipcMain.handle('getSubtitleAsVtt', async (event, { filePath }) => {
     try {
@@ -303,58 +387,59 @@ export function setupIpcHandlers(mainWindow: BrowserWindow) {
     'saveSubtitleFile',
     async (event, { filePath, subtitles, contentType = 'source' }) => {
       try {
-        const format = detectSubtitleFormat(filePath);
-        // 计算每条字幕实际要写入的可见文本（去掉模板带来的尾部空行，分隔交给序列化器处理）
-        const buildText = (subtitle): string => {
-          if (contentType === 'source') {
-            return subtitle.sourceContent ?? '';
-          }
-          return renderTemplate(CONTENT_TEMPLATES[contentType], {
-            sourceContent: subtitle.sourceContent ?? '',
-            targetContent: subtitle.targetContent ?? '',
-          }).replace(/\n+$/, '');
-        };
-
-        const content =
-          getSubtitleFileHeader(format) +
-          subtitles
-            .map((subtitle) => {
-              const { startMs, endMs } = parseStartEndTime(
-                subtitle.startEndTime,
-              );
-              return serializeCue(
-                {
-                  id: subtitle.id,
-                  startMs,
-                  endMs,
-                  text: buildText(subtitle),
-                },
-                format,
-              );
-            })
-            .join('');
-        // 覆盖前滚动备份一份到临时目录（避免污染用户视频目录；失败不阻断保存）
-        try {
-          if (fs.existsSync(filePath)) {
-            const backupPath = path.join(
-              ensureTempDir(),
-              `subtitle-backup-${getMd5(filePath)}${path.extname(filePath)}.bak`,
-            );
-            await fs.promises.copyFile(filePath, backupPath);
-          }
-        } catch (backupError) {
-          logMessage(
-            `备份字幕文件失败（继续保存）: ${backupError.message}`,
-            'warning',
-          );
-        }
-        await fs.promises.writeFile(filePath, content, 'utf-8');
-        logMessage(`保存字幕文件成功: ${filePath}`, 'info');
+        await writeSubtitleFile(filePath, subtitles, contentType);
         return { success: true };
       } catch (error) {
         logMessage(`保存字幕文件错误: ${error.message}`, 'error');
         return {
           error: `保存字幕文件错误: ${error.message}`,
+        };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'saveProofreadDataAndRender',
+    async (
+      event,
+      {
+        proofreadDataFile,
+        subtitles,
+        outputs = [],
+      }: {
+        proofreadDataFile: string;
+        subtitles: any[];
+        outputs: { filePath?: string; contentType?: string }[];
+      },
+    ) => {
+      try {
+        if (!proofreadDataFile || !fs.existsSync(proofreadDataFile)) {
+          throw new Error(
+            `Proofread data file not found: ${proofreadDataFile}`,
+          );
+        }
+
+        await updateProofreadDataFromSubtitles(proofreadDataFile, subtitles);
+
+        const rendered = new Set<string>();
+        for (const output of outputs) {
+          const filePath = output?.filePath;
+          if (!filePath) continue;
+          const key = path.resolve(filePath).toLowerCase();
+          if (rendered.has(key)) continue;
+          rendered.add(key);
+          await writeSubtitleFile(
+            filePath,
+            subtitles,
+            output.contentType || 'source',
+          );
+        }
+
+        return { success: true };
+      } catch (error) {
+        logMessage(`保存校对中间态错误: ${error.message}`, 'error');
+        return {
+          error: `保存校对中间态错误: ${error.message}`,
         };
       }
     },

--- a/main/helpers/proofreadData.ts
+++ b/main/helpers/proofreadData.ts
@@ -1,0 +1,240 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import type { IFiles } from '../../types';
+import {
+  detectSubtitleFormatFromContent,
+  parseStartEndTime,
+  parseSubtitleEntries,
+  toSrtTimeRange,
+  type SubtitleEntry,
+} from './subtitleFormats';
+import { logMessage } from './storeManager';
+
+export interface ProofreadDataCue {
+  id: string;
+  startMs: number;
+  endMs: number;
+  source: string;
+  target: string;
+}
+
+export interface ProofreadDataFile {
+  version: 1;
+  meta: {
+    createdAt: string;
+    updatedAt: string;
+    sourceLanguage?: string;
+    targetLanguage?: string;
+    translateContent?: string;
+    outputFormat?: string;
+    sourceFile?: string;
+    targetFile?: string;
+    finalTargetFile?: string;
+  };
+  cues: ProofreadDataCue[];
+}
+
+export interface ProofreadSubtitleRow {
+  id: string;
+  startEndTime: string;
+  content: string[];
+  sourceContent: string;
+  targetContent: string;
+  startTimeInSeconds: number;
+  endTimeInSeconds: number;
+  isEditing: boolean;
+}
+
+function safeFileNamePart(input: string): string {
+  const cleaned = input
+    .replace(/[<>:"/\\|?*\x00-\x1f]/g, '_')
+    .replace(/\s+/g, '_')
+    .replace(/^\.+/, '')
+    .slice(0, 80);
+  return cleaned || 'subtitle';
+}
+
+function hashId(input: string): string {
+  return crypto.createHash('md5').update(input).digest('hex').slice(0, 12);
+}
+
+export function getProofreadDataPath(file: IFiles): string {
+  const dir = file.directory || path.dirname(file.filePath);
+  const baseName = safeFileNamePart(
+    file.fileName || path.basename(file.filePath),
+  );
+  const id = safeFileNamePart(file.uuid || hashId(file.filePath || baseName));
+  return path.join(dir, '.smartsub-proofread', `${baseName}.${id}.json`);
+}
+
+async function readSubtitleEntries(
+  filePath?: string,
+): Promise<SubtitleEntry[]> {
+  if (!filePath || !fs.existsSync(filePath)) return [];
+  const content = await fs.promises.readFile(filePath, 'utf-8');
+  return parseSubtitleEntries(
+    content,
+    detectSubtitleFormatFromContent(filePath, content),
+  );
+}
+
+function entryText(entry?: SubtitleEntry): string {
+  return entry?.content?.join('\n') ?? '';
+}
+
+function buildCues(
+  sourceEntries: SubtitleEntry[],
+  targetEntries: SubtitleEntry[],
+): ProofreadDataCue[] {
+  const targetByTime = new Map<string, SubtitleEntry>();
+  for (const entry of targetEntries) {
+    if (!targetByTime.has(entry.startEndTime)) {
+      targetByTime.set(entry.startEndTime, entry);
+    }
+  }
+
+  return sourceEntries.map((sourceEntry, index) => {
+    const targetEntry =
+      targetByTime.get(sourceEntry.startEndTime) || targetEntries[index];
+    const { startMs, endMs } = parseStartEndTime(sourceEntry.startEndTime);
+
+    return {
+      id: sourceEntry.id || String(index + 1),
+      startMs,
+      endMs,
+      source: entryText(sourceEntry),
+      target: entryText(targetEntry),
+    };
+  });
+}
+
+export async function writeProofreadDataFromFiles({
+  file,
+  sourceFile,
+  targetFile,
+  finalTargetFile,
+  sourceLanguage,
+  targetLanguage,
+  translateContent,
+  outputFormat,
+}: {
+  file: IFiles;
+  sourceFile?: string;
+  targetFile?: string;
+  finalTargetFile?: string;
+  sourceLanguage?: string;
+  targetLanguage?: string;
+  translateContent?: string;
+  outputFormat?: string;
+}): Promise<string | null> {
+  try {
+    const sourceEntries = await readSubtitleEntries(sourceFile);
+    if (sourceEntries.length === 0) {
+      logMessage(
+        `skip proofread data: source subtitle has no cues (${sourceFile})`,
+        'warning',
+      );
+      return null;
+    }
+
+    const targetEntries = await readSubtitleEntries(targetFile);
+    const now = new Date().toISOString();
+    const proofreadData: ProofreadDataFile = {
+      version: 1,
+      meta: {
+        createdAt: now,
+        updatedAt: now,
+        sourceLanguage,
+        targetLanguage,
+        translateContent,
+        outputFormat,
+        sourceFile,
+        targetFile,
+        finalTargetFile,
+      },
+      cues: buildCues(sourceEntries, targetEntries),
+    };
+
+    const proofreadDataFile = getProofreadDataPath(file);
+    await fs.promises.mkdir(path.dirname(proofreadDataFile), {
+      recursive: true,
+    });
+    await fs.promises.writeFile(
+      proofreadDataFile,
+      JSON.stringify(proofreadData, null, 2),
+      'utf-8',
+    );
+    logMessage(`proofread data written: ${proofreadDataFile}`, 'info');
+    return proofreadDataFile;
+  } catch (error) {
+    logMessage(`write proofread data failed: ${error}`, 'warning');
+    return null;
+  }
+}
+
+export async function readProofreadDataFile(
+  filePath: string,
+): Promise<ProofreadDataFile> {
+  const content = await fs.promises.readFile(filePath, 'utf-8');
+  const parsed = JSON.parse(content) as ProofreadDataFile;
+  if (parsed?.version !== 1 || !Array.isArray(parsed.cues)) {
+    throw new Error(`Invalid proofread data file: ${filePath}`);
+  }
+  return parsed;
+}
+
+export function proofreadDataToSubtitleRows(
+  data: ProofreadDataFile,
+): ProofreadSubtitleRow[] {
+  return data.cues.map((cue, index) => {
+    const id = cue.id || String(index + 1);
+    const sourceContent = cue.source ?? '';
+    const targetContent = cue.target ?? '';
+    return {
+      id,
+      startEndTime: toSrtTimeRange(cue.startMs, cue.endMs),
+      content: sourceContent.split('\n'),
+      sourceContent,
+      targetContent,
+      startTimeInSeconds: cue.startMs / 1000,
+      endTimeInSeconds: cue.endMs / 1000,
+      isEditing: false,
+    };
+  });
+}
+
+export async function updateProofreadDataFromSubtitles(
+  filePath: string,
+  subtitles: ProofreadSubtitleRow[],
+): Promise<ProofreadDataFile> {
+  const existing = await readProofreadDataFile(filePath);
+  const now = new Date().toISOString();
+  const updated: ProofreadDataFile = {
+    ...existing,
+    meta: {
+      ...existing.meta,
+      updatedAt: now,
+    },
+    cues: subtitles.map((subtitle, index) => {
+      const { startMs, endMs } = parseStartEndTime(subtitle.startEndTime);
+      const source =
+        subtitle.sourceContent ?? subtitle.content?.join('\n') ?? '';
+      return {
+        id: subtitle.id || String(index + 1),
+        startMs,
+        endMs,
+        source,
+        target: subtitle.targetContent ?? '',
+      };
+    }),
+  };
+
+  await fs.promises.writeFile(
+    filePath,
+    JSON.stringify(updated, null, 2),
+    'utf-8',
+  );
+  logMessage(`proofread data updated: ${filePath}`, 'info');
+  return updated;
+}

--- a/renderer/components/proofread/ProofreadEditor.tsx
+++ b/renderer/components/proofread/ProofreadEditor.tsx
@@ -40,6 +40,7 @@ interface PendingFile {
   status: 'pending' | 'proofreading' | 'completed';
   finalTargetPath?: string; // 目标翻译文件路径（用户配置格式）
   translateContent?: string; // 翻译内容格式设置
+  proofreadDataFile?: string;
 }
 
 interface ProofreadEditorProps {
@@ -66,6 +67,7 @@ export default function ProofreadEditor({
       targetLanguage: file.targetLanguage,
       finalTargetSubtitlePath: file.finalTargetPath,
       translateContent: file.translateContent,
+      proofreadDataFile: file.proofreadDataFile,
     }),
     [file],
   );

--- a/renderer/components/proofread/ProofreadFileList.tsx
+++ b/renderer/components/proofread/ProofreadFileList.tsx
@@ -57,6 +57,10 @@ import {
 const SUBTITLE_SELECT_TRIGGER_CLASS =
   'h-auto min-h-10 w-full min-w-0 max-w-full [&>span]:line-clamp-none [&>span]:flex [&>span]:min-w-0 [&>span]:flex-1 [&>span]:w-full';
 
+function isPlainTextSubtitlePath(filePath?: string): boolean {
+  return /\.txt$/i.test(filePath || '');
+}
+
 interface SubtitleSelectLabelProps {
   filePath: string;
   language?: string;
@@ -544,6 +548,11 @@ export default function ProofreadFileList({
               const targetOptions = file.detectedSubtitles.filter(
                 (s) => s.filePath !== file.selectedSource,
               );
+              const hasPlainTextSubtitle =
+                isPlainTextSubtitlePath(file.selectedSource) ||
+                isPlainTextSubtitlePath(file.selectedTarget);
+              const canStartProofread =
+                Boolean(file.selectedSource) && !hasPlainTextSubtitle;
 
               return (
                 <TableRow key={file.id}>
@@ -699,17 +708,30 @@ export default function ProofreadFileList({
                   </TableCell>
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
-                      <Button
-                        variant="default"
-                        size="sm"
-                        onClick={() => onStartProofread(index)}
-                        disabled={!file.selectedSource}
-                      >
-                        <Play className="w-4 h-4 mr-1" />
-                        {file.status === 'completed'
-                          ? t('view')
-                          : t('proofread')}
-                      </Button>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="inline-flex">
+                              <Button
+                                variant="default"
+                                size="sm"
+                                onClick={() => onStartProofread(index)}
+                                disabled={!canStartProofread}
+                              >
+                                <Play className="w-4 h-4 mr-1" />
+                                {file.status === 'completed'
+                                  ? t('view')
+                                  : t('proofread')}
+                              </Button>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-[280px]">
+                            {hasPlainTextSubtitle
+                              ? t('proofreadTxtUnsupported')
+                              : t('proofread')}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                       <Button
                         variant="ghost"
                         size="icon"

--- a/renderer/components/proofread/ProofreadFileList.tsx
+++ b/renderer/components/proofread/ProofreadFileList.tsx
@@ -549,8 +549,9 @@ export default function ProofreadFileList({
                 (s) => s.filePath !== file.selectedSource,
               );
               const hasPlainTextSubtitle =
-                isPlainTextSubtitlePath(file.selectedSource) ||
-                isPlainTextSubtitlePath(file.selectedTarget);
+                !file.proofreadDataFile &&
+                (isPlainTextSubtitlePath(file.selectedSource) ||
+                  isPlainTextSubtitlePath(file.selectedTarget));
               const canStartProofread =
                 Boolean(file.selectedSource) && !hasPlainTextSubtitle;
 

--- a/renderer/components/tasks/CompletionBanner.tsx
+++ b/renderer/components/tasks/CompletionBanner.tsx
@@ -17,6 +17,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import type { TaskTypeDef } from 'lib/taskTypes';
 import { useTranslation } from 'next-i18next';
 import {
@@ -24,6 +30,8 @@ import {
   isFileTerminal,
   isFileDone,
   getRevealPath,
+  canProofreadFile,
+  getProofreadUnavailableReason,
 } from './stageUtils';
 
 interface CompletionBannerProps {
@@ -85,6 +93,17 @@ const CompletionBanner: React.FC<CompletionBannerProps> = ({
   const firstDone = doneFiles[0];
   const multiDone = doneFiles.length > 1;
   const isSample = projectId === 'sample-onboarding';
+  const hasProofreadableFile = doneFiles.some((file) =>
+    canProofreadFile(file, typeDef),
+  );
+  const firstProofreadUnavailableReason = getProofreadUnavailableReason(
+    firstDone,
+    typeDef,
+  );
+  const proofreadDisabledTooltip =
+    firstProofreadUnavailableReason === 'txt' || !hasProofreadableFile
+      ? t('row.proofreadTxtUnsupported')
+      : t('completion.goProofread');
 
   const handleOpenFolder = () => {
     const filePath = getRevealPath(firstDone);
@@ -167,7 +186,7 @@ const CompletionBanner: React.FC<CompletionBannerProps> = ({
         )}
       </div>
       <div className="flex items-center gap-2 flex-shrink-0">
-        {multiDone ? (
+        {multiDone && hasProofreadableFile ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm" className="h-7 text-xs gap-1">
@@ -177,27 +196,75 @@ const CompletionBanner: React.FC<CompletionBannerProps> = ({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="max-w-[320px]">
-              {doneFiles.map((file) => (
-                <DropdownMenuItem
-                  key={file.uuid}
-                  className="text-xs"
-                  onClick={() => onProofread(file)}
-                >
-                  <span className="truncate">{fileLabel(file)}</span>
-                </DropdownMenuItem>
-              ))}
+              {doneFiles.map((file) => {
+                const unavailableReason = getProofreadUnavailableReason(
+                  file,
+                  typeDef,
+                );
+                return (
+                  <DropdownMenuItem
+                    key={file.uuid}
+                    className="text-xs"
+                    disabled={unavailableReason !== null}
+                    onClick={() => onProofread(file)}
+                  >
+                    <span className="truncate">{fileLabel(file)}</span>
+                    {unavailableReason === 'txt' && (
+                      <span className="ml-2 shrink-0 text-[11px] text-muted-foreground">
+                        {t('row.proofreadTxtUnsupportedShort')}
+                      </span>
+                    )}
+                  </DropdownMenuItem>
+                );
+              })}
             </DropdownMenuContent>
           </DropdownMenu>
+        ) : multiDone ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-xs gap-1"
+                    disabled
+                  >
+                    <Edit2 className="h-3 w-3" />
+                    {t('completion.goProofread')}
+                    <ChevronDown className="h-3 w-3" />
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[280px]">
+                {proofreadDisabledTooltip}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ) : (
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 text-xs gap-1"
-            onClick={() => onProofread(firstDone)}
-          >
-            <Edit2 className="h-3 w-3" />
-            {t('completion.goProofread')}
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-xs gap-1"
+                    disabled={!canProofreadFile(firstDone, typeDef)}
+                    onClick={() => onProofread(firstDone)}
+                  >
+                    <Edit2 className="h-3 w-3" />
+                    {t('completion.goProofread')}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-[280px]">
+                {canProofreadFile(firstDone, typeDef)
+                  ? t('completion.goProofread')
+                  : proofreadDisabledTooltip}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )}
         {mergeableFiles.length > 1 ? (
           <DropdownMenu>

--- a/renderer/components/tasks/TaskGridList.tsx
+++ b/renderer/components/tasks/TaskGridList.tsx
@@ -31,6 +31,7 @@ import {
   getFileError,
   hasFileError,
   isProofreadReady,
+  getProofreadUnavailableReason,
   getRevealPath,
   formatBytes,
   formatMediaDuration,
@@ -186,6 +187,17 @@ const TaskGridList: React.FC<TaskGridListProps> = ({
         ]
           .filter(Boolean)
           .join(' · ');
+        const proofreadUnavailableReason = getProofreadUnavailableReason(
+          file,
+          typeDef,
+        );
+        const proofreadDisabled =
+          !isProofreadReady(file, typeDef) ||
+          proofreadUnavailableReason !== null;
+        const proofreadTooltip =
+          proofreadUnavailableReason === 'txt'
+            ? t('row.proofreadTxtUnsupported')
+            : t('row.proofread');
 
         return (
           <div
@@ -303,18 +315,22 @@ const TaskGridList: React.FC<TaskGridListProps> = ({
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7"
-                      aria-label={t('row.proofread')}
-                      disabled={!isProofreadReady(file, typeDef)}
-                      onClick={() => onProofread(file)}
-                    >
-                      <Edit2 className="h-3.5 w-3.5" />
-                    </Button>
+                    <span className="inline-flex">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7"
+                        aria-label={t('row.proofread')}
+                        disabled={proofreadDisabled}
+                        onClick={() => onProofread(file)}
+                      >
+                        <Edit2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </span>
                   </TooltipTrigger>
-                  <TooltipContent>{t('row.proofread')}</TooltipContent>
+                  <TooltipContent className="max-w-[280px]">
+                    {proofreadTooltip}
+                  </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
               <TooltipProvider>

--- a/renderer/components/tasks/TaskRowList.tsx
+++ b/renderer/components/tasks/TaskRowList.tsx
@@ -29,6 +29,7 @@ import {
   getFileError,
   hasFileError,
   isProofreadReady,
+  getProofreadUnavailableReason,
   getRevealPath,
   formatBytes,
   formatMediaDuration,
@@ -196,6 +197,17 @@ const TaskRowList: React.FC<TaskRowListProps> = ({
           .filter(Boolean)
           .join(' · ');
         const etaMinutes = getEtaMinutes(file, stages);
+        const proofreadUnavailableReason = getProofreadUnavailableReason(
+          file,
+          typeDef,
+        );
+        const proofreadDisabled =
+          !isProofreadReady(file, typeDef) ||
+          proofreadUnavailableReason !== null;
+        const proofreadTooltip =
+          proofreadUnavailableReason === 'txt'
+            ? t('row.proofreadTxtUnsupported')
+            : t('row.proofread');
 
         return (
           <div
@@ -282,18 +294,22 @@ const TaskRowList: React.FC<TaskRowListProps> = ({
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        aria-label={t('row.proofread')}
-                        disabled={!isProofreadReady(file, typeDef)}
-                        onClick={() => onProofread(file)}
-                      >
-                        <Edit2 className="h-3.5 w-3.5" />
-                      </Button>
+                      <span className="inline-flex">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7"
+                          aria-label={t('row.proofread')}
+                          disabled={proofreadDisabled}
+                          onClick={() => onProofread(file)}
+                        >
+                          <Edit2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </span>
                     </TooltipTrigger>
-                    <TooltipContent>{t('row.proofread')}</TooltipContent>
+                    <TooltipContent className="max-w-[280px]">
+                      {proofreadTooltip}
+                    </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
                 <TooltipProvider>

--- a/renderer/components/tasks/stageUtils.ts
+++ b/renderer/components/tasks/stageUtils.ts
@@ -86,6 +86,58 @@ export function isProofreadReady(file: any, typeDef: TaskTypeDef): boolean {
   return file?.translateSubtitle === 'done';
 }
 
+export type ProofreadUnavailableReason = 'txt';
+
+export function isPlainTextSubtitlePath(filePath?: string): boolean {
+  return /\.txt$/i.test(filePath || '');
+}
+
+export function getTaskProofreadSourcePath(
+  file: any,
+  typeDef: TaskTypeDef,
+): string {
+  const sourcePath =
+    file?.srtFile ||
+    file?.tempSrtFile ||
+    (isSubtitleFile(file?.filePath || '') ? file.filePath : '');
+
+  if (typeDef.taskType === 'generateOnly') {
+    return sourcePath;
+  }
+
+  return sourcePath;
+}
+
+export function getTaskProofreadTargetPath(
+  file: any,
+  typeDef: TaskTypeDef,
+): string {
+  if (typeDef.taskType === 'generateOnly') return '';
+  return file?.tempTranslatedSrtFile || file?.translatedSrtFile || '';
+}
+
+export function getProofreadUnavailableReason(
+  file: any,
+  typeDef: TaskTypeDef,
+): ProofreadUnavailableReason | null {
+  const sourcePath = getTaskProofreadSourcePath(file, typeDef);
+  const targetPath = getTaskProofreadTargetPath(file, typeDef);
+  if (
+    isPlainTextSubtitlePath(sourcePath) ||
+    isPlainTextSubtitlePath(targetPath)
+  ) {
+    return 'txt';
+  }
+  return null;
+}
+
+export function canProofreadFile(file: any, typeDef: TaskTypeDef): boolean {
+  return (
+    isProofreadReady(file, typeDef) &&
+    getProofreadUnavailableReason(file, typeDef) === null
+  );
+}
+
 /** 打开所在文件夹时优先揭示的产物路径 */
 export function getRevealPath(file: any): string {
   return file?.translatedSrtFile || file?.srtFile || file?.filePath || '';

--- a/renderer/components/tasks/stageUtils.ts
+++ b/renderer/components/tasks/stageUtils.ts
@@ -120,6 +120,8 @@ export function getProofreadUnavailableReason(
   file: any,
   typeDef: TaskTypeDef,
 ): ProofreadUnavailableReason | null {
+  if (file?.proofreadDataFile) return null;
+
   const sourcePath = getTaskProofreadSourcePath(file, typeDef);
   const targetPath = getTaskProofreadTargetPath(file, typeDef);
   if (

--- a/renderer/hooks/useStandaloneSubtitles.ts
+++ b/renderer/hooks/useStandaloneSubtitles.ts
@@ -18,6 +18,7 @@ interface StandaloneSubtitlesConfig {
   targetLanguage?: string;
   finalTargetSubtitlePath?: string; // 目标翻译文件（用户配置格式，可能是双语）
   translateContent?: string; // 翻译内容格式设置
+  proofreadDataFile?: string;
 }
 
 // 将时间字符串转换为秒
@@ -119,6 +120,23 @@ export const useStandaloneSubtitles = (
     }
   };
 
+  const readProofreadDataFile = async (
+    filePath: string,
+  ): Promise<Subtitle[]> => {
+    try {
+      const result: Subtitle[] = await window.ipc.invoke(
+        'readProofreadDataFile',
+        {
+          filePath,
+        },
+      );
+      return result;
+    } catch (error) {
+      console.error('Error reading proofread data file:', error);
+      return [];
+    }
+  };
+
   // 创建播放器字幕轨道
   const createPlayerTrack = async (
     srtPath: string | undefined,
@@ -163,7 +181,13 @@ export const useStandaloneSubtitles = (
       const playerTracks: PlayerSubtitleTrack[] = [];
 
       // 读取源字幕
-      const sourceSubtitles = await readSubtitleFile(config.sourceSubtitlePath);
+      const proofreadDataSubtitles = config.proofreadDataFile
+        ? await readProofreadDataFile(config.proofreadDataFile)
+        : [];
+      const sourceSubtitles =
+        proofreadDataSubtitles.length > 0
+          ? proofreadDataSubtitles
+          : await readSubtitleFile(config.sourceSubtitlePath);
       if (config.sourceLanguage) {
         const track = await createPlayerTrack(
           config.sourceSubtitlePath,
@@ -175,7 +199,21 @@ export const useStandaloneSubtitles = (
 
       // 读取翻译字幕
       let translatedSubtitles: Subtitle[] = [];
-      if (config.targetSubtitlePath) {
+      if (proofreadDataSubtitles.length > 0) {
+        setHasTranslationFile(
+          proofreadDataSubtitles.some(
+            (sub) => sub.targetContent && sub.targetContent.trim() !== '',
+          ),
+        );
+        if (config.targetSubtitlePath && config.targetLanguage) {
+          const track = await createPlayerTrack(
+            config.targetSubtitlePath,
+            config.targetLanguage,
+            true,
+          );
+          if (track) playerTracks.push(track);
+        }
+      } else if (config.targetSubtitlePath) {
         translatedSubtitles = await readSubtitleFile(config.targetSubtitlePath);
         setHasTranslationFile(translatedSubtitles.length > 0);
 
@@ -199,6 +237,10 @@ export const useStandaloneSubtitles = (
         });
 
         const merged = sourceSubtitles.map((sub, index) => {
+          if (proofreadDataSubtitles.length > 0) {
+            return { ...sub, isEditing: false };
+          }
+
           const translated =
             translatedMap.get(sub.startEndTime) ||
             (index < translatedSubtitles.length
@@ -315,6 +357,52 @@ export const useStandaloneSubtitles = (
     // 先把未提交的逐字编辑补入撤销历史，保证保存后仍可撤销
     flushPendingEdit();
     try {
+      if (config.proofreadDataFile) {
+        const outputs: { filePath?: string; contentType?: string }[] = [];
+        const finalTargetPath = config.finalTargetSubtitlePath;
+
+        if (config.sourceSubtitlePath) {
+          outputs.push({
+            filePath: config.sourceSubtitlePath,
+            contentType: 'source',
+          });
+        }
+
+        if (shouldShowTranslation) {
+          if (
+            config.targetSubtitlePath &&
+            config.targetSubtitlePath !== finalTargetPath
+          ) {
+            outputs.push({
+              filePath: config.targetSubtitlePath,
+              contentType: 'onlyTranslate',
+            });
+          }
+          outputs.push({
+            filePath: finalTargetPath || config.targetSubtitlePath,
+            contentType: finalTargetPath
+              ? config.translateContent || 'onlyTranslate'
+              : 'onlyTranslate',
+          });
+        }
+
+        const result = await window.ipc.invoke('saveProofreadDataAndRender', {
+          proofreadDataFile: config.proofreadDataFile,
+          subtitles: mergedSubtitles,
+          outputs: outputs.filter((output) => output.filePath),
+        });
+
+        if (result?.error) {
+          console.error('Error saving proofread data:', result.error);
+          toast.error(t('saveFailed'));
+          return false;
+        }
+
+        setIsDirty(false);
+        toast.success(t('subtitleSavedSuccess'));
+        return true;
+      }
+
       const results: { error?: string }[] = [];
 
       // 保存源字幕

--- a/renderer/lib/proofreadUtils.ts
+++ b/renderer/lib/proofreadUtils.ts
@@ -22,6 +22,9 @@ export interface PendingFile {
   detectedSubtitles: DetectedSubtitle[];
   selectedSource?: string;
   selectedTarget?: string;
+  proofreadDataFile?: string;
+  finalTargetPath?: string;
+  translateContent?: string;
   sourceLanguage?: string;
   targetLanguage?: string;
   status: 'pending' | 'proofreading' | 'completed';
@@ -273,6 +276,7 @@ export async function loadPendingFileFromItem(item: {
   videoPath?: string;
   sourceSubtitlePath: string;
   targetSubtitlePath?: string;
+  proofreadDataFile?: string;
   sourceLanguage?: string;
   targetLanguage?: string;
   status: 'pending' | 'in_progress' | 'completed';
@@ -333,6 +337,7 @@ export async function loadPendingFileFromItem(item: {
     detectedSubtitles,
     selectedSource: item.sourceSubtitlePath,
     selectedTarget: item.targetSubtitlePath,
+    proofreadDataFile: item.proofreadDataFile,
     sourceLanguage: item.sourceLanguage,
     targetLanguage: item.targetLanguage,
     status: item.status === 'completed' ? 'completed' : 'pending',
@@ -348,6 +353,7 @@ export function pendingFileToSaveFormat(file: PendingFile): {
   videoPath?: string;
   sourceSubtitlePath: string;
   targetSubtitlePath?: string;
+  proofreadDataFile?: string;
   sourceLanguage?: string;
   targetLanguage?: string;
   detectedSubtitles: DetectedSubtitle[];
@@ -366,6 +372,7 @@ export function pendingFileToSaveFormat(file: PendingFile): {
     videoPath: file.videoPath,
     sourceSubtitlePath: file.selectedSource || '',
     targetSubtitlePath: file.selectedTarget,
+    proofreadDataFile: file.proofreadDataFile,
     sourceLanguage: file.sourceLanguage,
     targetLanguage: file.targetLanguage,
     detectedSubtitles: file.detectedSubtitles.map((s) => ({

--- a/renderer/pages/[locale]/tasks/[type].tsx
+++ b/renderer/pages/[locale]/tasks/[type].tsx
@@ -465,6 +465,7 @@ export default function TaskPage() {
       status: 'proofreading' as const,
       finalTargetPath,
       translateContent: formData.translateContent,
+      proofreadDataFile: proofreadFile.proofreadDataFile,
     };
   }, [proofreadFile, typeDef, formData]);
 

--- a/renderer/pages/[locale]/tasks/[type].tsx
+++ b/renderer/pages/[locale]/tasks/[type].tsx
@@ -45,6 +45,7 @@ import TaskGridList from '@/components/tasks/TaskGridList';
 import CompletionBanner from '@/components/tasks/CompletionBanner';
 import LogPanel from '@/components/tasks/LogPanel';
 import { ProofreadEditor } from '@/components/proofread';
+import { getProofreadUnavailableReason } from '@/components/tasks/stageUtils';
 import { getI18nProperties } from '../../../lib/get-static';
 import { IFiles } from '../../../../types';
 import { useTranslation } from 'next-i18next';
@@ -360,6 +361,19 @@ export default function TaskPage() {
     });
   };
 
+  const handleProofread = useCallback(
+    (file: IFiles) => {
+      if (!typeDef) return;
+      const unavailableReason = getProofreadUnavailableReason(file, typeDef);
+      if (unavailableReason === 'txt') {
+        toast.info(t('row.proofreadTxtUnsupported'));
+        return;
+      }
+      setProofreadFile(file);
+    },
+    [t, typeDef],
+  );
+
   const startRename = () => {
     setNameDraft(projectName || '');
     setEditingName(true);
@@ -609,7 +623,7 @@ export default function TaskPage() {
         dismissed={bannerDismissed}
         projectId={projectId}
         onDismiss={() => setBannerDismissed(true)}
-        onProofread={(file) => setProofreadFile(file)}
+        onProofread={handleProofread}
         onRetryFailed={handleRetryFailed}
       />
 
@@ -629,7 +643,7 @@ export default function TaskPage() {
               typeDef={typeDef}
               formData={formData}
               taskStatus={taskStatus}
-              onProofread={(file) => setProofreadFile(file)}
+              onProofread={handleProofread}
               onDelete={(uuid) =>
                 setFiles((prev) => prev.filter((f) => f.uuid !== uuid))
               }
@@ -641,7 +655,7 @@ export default function TaskPage() {
               typeDef={typeDef}
               formData={formData}
               taskStatus={taskStatus}
-              onProofread={(file) => setProofreadFile(file)}
+              onProofread={handleProofread}
               onDelete={(uuid) =>
                 setFiles((prev) => prev.filter((f) => f.uuid !== uuid))
               }

--- a/renderer/public/locales/en/home.json
+++ b/renderer/public/locales/en/home.json
@@ -57,6 +57,7 @@
   "noContext": "Minimize subtitle repetition(0)",
   "importSubtitles": "Import Subtitles",
   "proofread": "Proofread",
+  "proofreadTxtUnsupported": "TXT files do not include timing, so they cannot be proofread here. Select SRT/VTT/ASS subtitles with timing instead.",
   "subtitleProofread": "Subtitle Proofreading",
   "sourceSubtitle": "Source Subtitle",
   "targetSubtitle": "Translated Subtitle",

--- a/renderer/public/locales/en/tasks.json
+++ b/renderer/public/locales/en/tasks.json
@@ -54,7 +54,9 @@
     "openFolder": "Show in folder",
     "retry": "Retry",
     "remove": "Remove",
-    "embeddedSubtitle": "Extracted from embedded subtitles"
+    "embeddedSubtitle": "Extracted from embedded subtitles",
+    "proofreadTxtUnsupported": "TXT files do not include timing, so they cannot be proofread here. Generate SRT/VTT/ASS for proofreading, then export plain text after proofreading.",
+    "proofreadTxtUnsupportedShort": "TXT not supported"
   },
   "waiting": "Waiting",
   "interrupted": "Interrupted by app restart — retry to continue",

--- a/renderer/public/locales/zh/home.json
+++ b/renderer/public/locales/zh/home.json
@@ -57,6 +57,7 @@
   "generateOnly": "仅生成字幕",
   "translateOnly": "仅翻译字幕",
   "proofread": "校对",
+  "proofreadTxtUnsupported": "TXT 文件不包含时间轴，暂不支持校对。请选择 SRT/VTT/ASS 等包含时间轴的字幕文件。",
   "subtitleProofread": "字幕校对",
   "sourceSubtitle": "原文字幕",
   "targetSubtitle": "翻译字幕",

--- a/renderer/public/locales/zh/tasks.json
+++ b/renderer/public/locales/zh/tasks.json
@@ -54,7 +54,9 @@
     "openFolder": "打开所在文件夹",
     "retry": "重试",
     "remove": "移除",
-    "embeddedSubtitle": "内封软字幕直提（已跳过听写/ASR）"
+    "embeddedSubtitle": "内封软字幕直提（已跳过听写/ASR）",
+    "proofreadTxtUnsupported": "TXT 文件不包含时间轴，暂不支持校对。请生成 SRT/VTT/ASS 后校对，或校对完成后另存为 TXT。",
+    "proofreadTxtUnsupportedShort": "TXT 不支持校对"
   },
   "waiting": "等待中",
   "interrupted": "上次运行被中断，点击重试继续",

--- a/types/proofread.ts
+++ b/types/proofread.ts
@@ -50,6 +50,7 @@ export interface ProofreadItem {
   videoPath?: string;
   sourceSubtitlePath: string;
   targetSubtitlePath?: string;
+  proofreadDataFile?: string;
   sourceLanguage?: string; // 自动检测的语言
   targetLanguage?: string;
   lastPosition: number; // 上次校对到的字幕索引
@@ -79,6 +80,7 @@ export interface ProofreadHistory {
   videoPath?: string;
   sourceSubtitlePath: string;
   targetSubtitlePath?: string;
+  proofreadDataFile?: string;
   sourceLanguage: string;
   targetLanguage: string;
   lastPosition: number;
@@ -93,6 +95,7 @@ export interface StandaloneSubtitleConfig {
   videoPath?: string;
   sourceSubtitlePath: string;
   targetSubtitlePath?: string;
+  proofreadDataFile?: string;
   sourceLanguage?: string;
   targetLanguage?: string;
 }

--- a/types/types.ts
+++ b/types/types.ts
@@ -49,6 +49,8 @@ export interface IFiles {
   tempAudioFile?: string;
   translatedSrtFile?: string;
   tempTranslatedSrtFile?: string;
+  /** 校对用无损中间态 sidecar，保存源文/译文/时间轴，避免直接读写有损交付物。 */
+  proofreadDataFile?: string;
   /** 本次转写实际使用的后端标签（如 "CUDA 12.4.0" / "Vulkan" / "CPU"） */
   whisperBackend?: string;
   /** 该文件走了内封软字幕直提（跳过抽音频 + ASR）：用于任务列表标识 */


### PR DESCRIPTION
## 摘要

- 在任务列表、网格视图和完成横幅里识别 TXT 产物；遇到 TXT 时禁用“校对/去校对”入口，并在悬停提示里说明原因。
- 在任务页进入校对编辑器前增加兜底拦截，避免后续入口漏掉判断时打开空白校对页。
- 在独立校对页的文件列表中，如果选中的源字幕或翻译字幕是纯 TXT，也禁用开始校对按钮并给出同样提示。
- 补充中英文文案，明确“TXT 文件不包含时间轴，暂不支持校对”。

## 为什么这样改

TXT 是纯文本格式，没有字幕起止时间；校对页依赖时间轴来逐条定位字幕和视频。之前生成 TXT 后仍然可以点击“校对”，进入后看不到字幕内容，用户容易误解为字幕丢失或校对功能异常。

这次改动不禁止生成 TXT，只是在进入校对前把不支持的原因说明清楚。用户需要校对时，应先生成 SRT/VTT/ASS 等带时间轴的字幕；校对完成后再导出或保存为纯文本。

close #350

## 验证

- `npm run check:i18n`
- `git diff --check`
- `npx tsc --noEmit` 未通过：被仓库既有 docs Docusaurus 依赖缺失、路径别名、Jest 类型和旧参数配置类型问题阻塞。
- `npx tsc -p renderer/tsconfig.json --noEmit` 未通过：被现有 renderer 测试缺少 Jest/@testing-library 类型，以及旧参数配置类型问题阻塞。