### PR TITLE
feat: 服务商下拉分组展示与首屏预取优化跳转卡顿

### DIFF
--- a/renderer/components/Layout.tsx
+++ b/renderer/components/Layout.tsx
@@ -42,6 +42,7 @@ import ActivityCenter from './ActivityCenter';
 import CommandPalette from './CommandPalette';
 import { cn, openUrl } from 'lib/utils';
 import { hasAnyModelAnyEngine } from 'lib/engineModels';
+import { TASK_TYPES } from 'lib/taskTypes';
 import { useRouter } from 'next/router';
 import { toast } from 'sonner';
 import { Toaster } from '@/components/ui/sonner';
@@ -119,6 +120,20 @@ const NAV_ITEMS: NavItemDef[] = [
   },
 ];
 
+// 全部页面用到的 i18n 语言包：首屏空闲后一次性预加载，避免逐页按需 fetch 造成的切换延迟
+const PREFETCH_NAMESPACES = [
+  'common',
+  'home',
+  'tasks',
+  'launchpad',
+  'settings',
+  'translateControl',
+  'resources',
+  'subtitleMerge',
+  'parameters',
+  'modelsControl',
+];
+
 function NavItem({
   item,
   locale,
@@ -167,10 +182,8 @@ function NavItem({
 const openAfterMenuClose = (open: () => void) => setTimeout(open, 0);
 
 const Layout = ({ children }) => {
-  const {
-    t,
-    i18n: { language: locale },
-  } = useTranslation('common');
+  const { t, i18n } = useTranslation('common');
+  const locale = i18n.language;
   const router = useRouter();
   // 兜底清理 Radix 残留的 body pointer-events 锁（从帮助菜单打开弹窗关闭后整页失效）
   useRadixPointerEventsGuard();
@@ -493,6 +506,44 @@ const Layout = ({ children }) => {
       if (hideTimer) clearTimeout(hideTimer);
     };
   }, []);
+
+  // 首屏空闲后预取各主路由的页面 bundle：静态导出下每页是独立 chunk，首次进入需现加载，
+  // 造成跳转卡顿。本地应用预取无流量成本，提前备好后点击即达。失败静默。
+  useEffect(() => {
+    if (!locale) return;
+    const routes = [
+      ...NAV_ITEMS.map((item) => item.href),
+      'recent-tasks',
+      ...TASK_TYPES.map((tt) => `tasks/${tt.slug}`),
+    ];
+    const run = () => {
+      routes.forEach((r) => {
+        void router.prefetch(`/${locale}/${r}`).catch(() => {});
+      });
+      // 预加载全部语言包，避免首次进入某页时再 fetch 该页 namespace 的延迟
+      void i18n.loadNamespaces(PREFETCH_NAMESPACES).catch(() => {});
+    };
+    const w = window as unknown as {
+      requestIdleCallback?: (
+        cb: () => void,
+        opts?: { timeout: number },
+      ) => number;
+      cancelIdleCallback?: (id: number) => void;
+    };
+    const id =
+      typeof w.requestIdleCallback === 'function'
+        ? w.requestIdleCallback(run, { timeout: 2000 })
+        : (setTimeout(run, 1200) as unknown as number);
+    return () => {
+      if (typeof w.cancelIdleCallback === 'function') {
+        w.cancelIdleCallback(id);
+      } else {
+        clearTimeout(id);
+      }
+    };
+    // router 故意不入依赖：避免每次路由切换重置预取计时器；prefetch 幂等且失败静默
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [locale]);
 
   const handleUpdateClick = () => {
     setShowUpdateDialog(true);

--- a/renderer/components/subtitle/BatchAiOptimizeDialog.tsx
+++ b/renderer/components/subtitle/BatchAiOptimizeDialog.tsx
@@ -19,10 +19,13 @@ import {
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { isProviderConfigured } from 'lib/providerUtils';
 import {
   Sparkles,
   Loader2,
@@ -133,8 +136,12 @@ IMPORTANT: Return ONLY a valid JSON object with subtitle IDs as keys and optimiz
       const result = await window.ipc.invoke('getAiTranslationProviders');
       if (result.success && result.data) {
         setAiProviders(result.data);
+        // 默认优先选中已配置的服务商，避免默认落到不可用项
         if (result.data.length > 0 && !selectedProviderId) {
-          setSelectedProviderId(result.data[0].id);
+          const firstConfigured = result.data.find((p: any) =>
+            isProviderConfigured(p),
+          );
+          if (firstConfigured) setSelectedProviderId(firstConfigured.id);
         }
       }
     } catch (error) {
@@ -213,7 +220,7 @@ IMPORTANT: Return ONLY a valid JSON object with subtitle IDs as keys and optimiz
 
   // 开始批量优化
   const handleStartOptimization = useCallback(async () => {
-    if (aiProviders.length === 0) {
+    if (!aiProviders.some((p) => isProviderConfigured(p))) {
       toast.error(t('noAiProviderConfigured'));
       return;
     }
@@ -415,7 +422,7 @@ IMPORTANT: Return ONLY a valid JSON object with subtitle IDs as keys and optimiz
               {/* AI 服务商选择 */}
               <div className="space-y-2">
                 <Label>{t('selectAiProvider')}</Label>
-                {aiProviders.length === 0 ? (
+                {!aiProviders.some((p) => isProviderConfigured(p)) ? (
                   <div className="p-3 border rounded bg-muted/30 text-sm text-muted-foreground italic">
                     {t('noAiProviderConfigured')}
                   </div>
@@ -428,11 +435,41 @@ IMPORTANT: Return ONLY a valid JSON object with subtitle IDs as keys and optimiz
                       <SelectValue placeholder={t('selectProvider')} />
                     </SelectTrigger>
                     <SelectContent>
-                      {aiProviders.map((provider) => (
-                        <SelectItem key={provider.id} value={provider.id}>
-                          {provider.name}
-                        </SelectItem>
-                      ))}
+                      {aiProviders.some((p) => isProviderConfigured(p)) && (
+                        <SelectGroup>
+                          <SelectLabel className="flex items-center gap-1.5 pl-2 text-foreground">
+                            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                            {t('providerGroup.configured')}
+                          </SelectLabel>
+                          {aiProviders
+                            .filter((p) => isProviderConfigured(p))
+                            .map((provider) => (
+                              <SelectItem key={provider.id} value={provider.id}>
+                                {provider.name}
+                              </SelectItem>
+                            ))}
+                        </SelectGroup>
+                      )}
+                      {aiProviders.some((p) => !isProviderConfigured(p)) && (
+                        <SelectGroup>
+                          <SelectLabel className="flex items-center gap-1.5 pl-2 text-muted-foreground">
+                            <AlertCircle className="h-3.5 w-3.5" />
+                            {t('providerGroup.notConfigured')}
+                          </SelectLabel>
+                          {aiProviders
+                            .filter((p) => !isProviderConfigured(p))
+                            .map((provider) => (
+                              <SelectItem
+                                key={provider.id}
+                                value={provider.id}
+                                disabled
+                              >
+                                {provider.name}
+                                {t('notConfigured')}
+                              </SelectItem>
+                            ))}
+                        </SelectGroup>
+                      )}
                     </SelectContent>
                   </Select>
                 )}
@@ -729,7 +766,7 @@ IMPORTANT: Return ONLY a valid JSON object with subtitle IDs as keys and optimiz
               <Button
                 onClick={handleStartOptimization}
                 disabled={
-                  aiProviders.length === 0 ||
+                  !aiProviders.some((p) => isProviderConfigured(p)) ||
                   subtitles.filter((s) => s.sourceContent?.trim()).length === 0
                 }
               >

--- a/renderer/components/subtitle/SubtitleEditToolbar.tsx
+++ b/renderer/components/subtitle/SubtitleEditToolbar.tsx
@@ -21,10 +21,13 @@ import {
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { isProviderConfigured } from 'lib/providerUtils';
 import {
   Search,
   Replace,
@@ -46,6 +49,8 @@ import {
   RotateCcw,
   X,
   Check,
+  CheckCircle2,
+  AlertCircle,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -496,9 +501,12 @@ Only respond with the corrected text, nothing else.`;
       const result = await window.ipc.invoke('getAiTranslationProviders');
       if (result.success && result.data) {
         setAiProviders(result.data);
-        // 默认选择第一个服务商
+        // 默认优先选中已配置的服务商，避免默认落到不可用项
         if (result.data.length > 0 && !selectedProviderId) {
-          setSelectedProviderId(result.data[0].id);
+          const firstConfigured = result.data.find((p: any) =>
+            isProviderConfigured(p),
+          );
+          if (firstConfigured) setSelectedProviderId(firstConfigured.id);
         }
       }
     } catch (error) {
@@ -615,7 +623,7 @@ Only respond with the corrected text, nothing else.`;
 
     // 如果没有翻译内容，也可以使用 AI 生成翻译
 
-    if (aiProviders.length === 0) {
+    if (!aiProviders.some((p) => isProviderConfigured(p))) {
       toast.error(t('noAiProviderConfigured'));
       return;
     }
@@ -1065,7 +1073,7 @@ Only respond with the corrected text, nothing else.`;
                 {/* AI 服务商选择 */}
                 <div className="space-y-2">
                   <Label>{t('selectAiProvider')}</Label>
-                  {aiProviders.length === 0 ? (
+                  {!aiProviders.some((p) => isProviderConfigured(p)) ? (
                     <div className="p-3 border rounded bg-muted/30 text-sm text-muted-foreground italic">
                       {t('noAiProviderConfigured')}
                     </div>
@@ -1078,11 +1086,44 @@ Only respond with the corrected text, nothing else.`;
                         <SelectValue placeholder={t('selectProvider')} />
                       </SelectTrigger>
                       <SelectContent>
-                        {aiProviders.map((provider) => (
-                          <SelectItem key={provider.id} value={provider.id}>
-                            {provider.name}
-                          </SelectItem>
-                        ))}
+                        {aiProviders.some((p) => isProviderConfigured(p)) && (
+                          <SelectGroup>
+                            <SelectLabel className="flex items-center gap-1.5 pl-2 text-foreground">
+                              <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                              {t('providerGroup.configured')}
+                            </SelectLabel>
+                            {aiProviders
+                              .filter((p) => isProviderConfigured(p))
+                              .map((provider) => (
+                                <SelectItem
+                                  key={provider.id}
+                                  value={provider.id}
+                                >
+                                  {provider.name}
+                                </SelectItem>
+                              ))}
+                          </SelectGroup>
+                        )}
+                        {aiProviders.some((p) => !isProviderConfigured(p)) && (
+                          <SelectGroup>
+                            <SelectLabel className="flex items-center gap-1.5 pl-2 text-muted-foreground">
+                              <AlertCircle className="h-3.5 w-3.5" />
+                              {t('providerGroup.notConfigured')}
+                            </SelectLabel>
+                            {aiProviders
+                              .filter((p) => !isProviderConfigured(p))
+                              .map((provider) => (
+                                <SelectItem
+                                  key={provider.id}
+                                  value={provider.id}
+                                  disabled
+                                >
+                                  {provider.name}
+                                  {t('notConfigured')}
+                                </SelectItem>
+                              ))}
+                          </SelectGroup>
+                        )}
                       </SelectContent>
                     </Select>
                   )}
@@ -1198,7 +1239,7 @@ Only respond with the corrected text, nothing else.`;
               disabled={
                 aiOptimizing ||
                 currentSubtitleIndex < 0 ||
-                aiProviders.length === 0
+                !aiProviders.some((p) => isProviderConfigured(p))
               }
             >
               {aiOptimizing ? (

--- a/renderer/components/tasks/InlineConfigBar.tsx
+++ b/renderer/components/tasks/InlineConfigBar.tsx
@@ -4,11 +4,13 @@ import { useRouter } from 'next/router';
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Download, Languages } from 'lucide-react';
+import { AlertCircle, CheckCircle2, Download, Languages } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Models from '@/components/Models';
 import { supportedLanguage } from 'lib/utils';
@@ -90,6 +92,30 @@ const InlineConfigBar: React.FC<InlineConfigBarProps> = ({
         </SelectItem>
       ))}
     </SelectContent>
+  );
+
+  // 已配置的服务商前置并独立分组，未配置的灰色置后：兼顾「可用项触手可及」与「发现性」
+  const { configuredProviders, unconfiguredProviders } = React.useMemo(() => {
+    const configured: Provider[] = [];
+    const unconfigured: Provider[] = [];
+    providers.forEach((provider) => {
+      if (isProviderConfigured(provider as any)) {
+        configured.push(provider);
+      } else {
+        unconfigured.push(provider);
+      }
+    });
+    return {
+      configuredProviders: configured,
+      unconfiguredProviders: unconfigured,
+    };
+  }, [providers]);
+
+  const renderProviderItem = (provider: Provider, configured: boolean) => (
+    <SelectItem key={provider.id} value={provider.id} disabled={!configured}>
+      {tCommon(`provider.${provider.name}`, { defaultValue: provider.name })}
+      {!configured && t('notConfigured')}
+    </SelectItem>
   );
 
   return (
@@ -179,21 +205,28 @@ const InlineConfigBar: React.FC<InlineConfigBarProps> = ({
                   <SelectValue placeholder={tHome('pleaseSelect')} />
                 </SelectTrigger>
                 <SelectContent>
-                  {providers.map((provider) => {
-                    const configured = isProviderConfigured(provider as any);
-                    return (
-                      <SelectItem
-                        key={provider.id}
-                        value={provider.id}
-                        disabled={!configured}
-                      >
-                        {tCommon(`provider.${provider.name}`, {
-                          defaultValue: provider.name,
-                        })}
-                        {!configured && t('notConfigured')}
-                      </SelectItem>
-                    );
-                  })}
+                  {configuredProviders.length > 0 && (
+                    <SelectGroup>
+                      <SelectLabel className="flex items-center gap-1.5 pl-2 text-foreground">
+                        <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                        {t('providerGroup.configured')}
+                      </SelectLabel>
+                      {configuredProviders.map((provider) =>
+                        renderProviderItem(provider, true),
+                      )}
+                    </SelectGroup>
+                  )}
+                  {unconfiguredProviders.length > 0 && (
+                    <SelectGroup>
+                      <SelectLabel className="flex items-center gap-1.5 pl-2 text-muted-foreground">
+                        <AlertCircle className="h-3.5 w-3.5" />
+                        {t('providerGroup.notConfigured')}
+                      </SelectLabel>
+                      {unconfiguredProviders.map((provider) =>
+                        renderProviderItem(provider, false),
+                      )}
+                    </SelectGroup>
+                  )}
                 </SelectContent>
               </Select>
             ) : (

--- a/renderer/public/locales/en/home.json
+++ b/renderer/public/locales/en/home.json
@@ -245,6 +245,11 @@
   "selectAiProvider": "Select AI Service",
   "selectProvider": "Select Provider",
   "noAiProviderConfigured": "No AI translation service configured, please add one in settings",
+  "notConfigured": " (not configured)",
+  "providerGroup": {
+    "configured": "Configured",
+    "notConfigured": "Others (not configured)"
+  },
   "customPrompt": "Optimization Prompt",
   "showCustomPrompt": "Expand",
   "hideCustomPrompt": "Collapse",

--- a/renderer/public/locales/en/tasks.json
+++ b/renderer/public/locales/en/tasks.json
@@ -17,6 +17,10 @@
     "format": "Subtitle format"
   },
   "notConfigured": " (not configured)",
+  "providerGroup": {
+    "configured": "Configured",
+    "notConfigured": "Others (not configured)"
+  },
   "skippedDuplicates": "Skipped {{count}} duplicate file(s)",
   "goDownloadModel": "Download a model",
   "goConfigureProvider": "Set up a translation service",

--- a/renderer/public/locales/zh/home.json
+++ b/renderer/public/locales/zh/home.json
@@ -245,6 +245,11 @@
   "selectAiProvider": "选择 AI 服务",
   "selectProvider": "选择服务商",
   "noAiProviderConfigured": "未配置 AI 翻译服务，请先在设置中添加",
+  "notConfigured": "（未配置）",
+  "providerGroup": {
+    "configured": "已配置",
+    "notConfigured": "其它（未配置）"
+  },
   "customPrompt": "优化提示词",
   "showCustomPrompt": "展开",
   "hideCustomPrompt": "收起",

--- a/renderer/public/locales/zh/tasks.json
+++ b/renderer/public/locales/zh/tasks.json
@@ -17,6 +17,10 @@
     "format": "字幕格式"
   },
   "notConfigured": "（未配置）",
+  "providerGroup": {
+    "configured": "已配置",
+    "notConfigured": "其它（未配置）"
+  },
   "skippedDuplicates": "已跳过 {{count}} 个重复文件",
   "goDownloadModel": "去下载模型",
   "goConfigureProvider": "去配置翻译服务",


### PR DESCRIPTION
## Summary

本 PR 包含两个独立主题（各一个原子提交）：

### 1. 服务商下拉「已配置优先 + 分组」展示
- 任务页翻译服务商（`InlineConfigBar`）、字幕校对（`SubtitleEditToolbar`）、批量 AI 优化（`BatchAiOptimizeDialog`）三处下拉统一为：
  - **已配置项**前置成组，带绿色对勾图标
  - **未配置项**灰显置后、禁用，标注「未配置」，分组标题带图标区分
- AI 优化默认选中**首个已配置项**；可用性判断由「列表非空」改为「存在已配置项」，避免默认落到不可用项导致报错
- 同步补充中英文 locale 文案（`providerGroup.configured` / `providerGroup.notConfigured` / `notConfigured`）

### 2. 首屏空闲预取，降低跳转卡顿
- 静态导出下每页是独立 chunk、i18n 按页 fetch namespace，首次进入某页有明显延迟
- `Layout` 在首屏空闲时（`requestIdleCallback`，`setTimeout` 兜底）预取全部主路由与任务页 bundle，并一次性 `loadNamespaces` 预加载语言包
- 预取幂等、失败静默、不阻塞首屏；`router` 不入依赖避免重置计时器

## Test plan

- [ ] 三处下拉：已配置在上（绿勾），未配置灰显禁用在下，分组标题图标正确
- [ ] 未配置任何 AI 服务时，开始/优化按钮禁用并提示「未配置」
- [ ] 已配置时默认选中首个已配置项
- [ ] 中英文 locale 文案均正确
- [ ] 生产包冷启动后停留 1-2 秒，再点各页/任务页跳转明显更快、无「加载语言文档」延迟