### PR TITLE
fix: 修复任务并发被单引擎队列误钳制

### DIFF
--- a/main/helpers/taskProcessor.ts
+++ b/main/helpers/taskProcessor.ts
@@ -14,10 +14,8 @@ import { killFfmpegForFiles } from './audioProcessor';
 import {
   listEngineAdapters,
   getEngineAdapterForTask,
-  resolveEngineIdForTask,
 } from './engines/registry';
 import { getPythonRuntimeManager } from './pythonRuntime';
-import type { TranscriptionEngine } from '../../types/engine';
 import {
   acquireTaskPowerSaveBlocker,
   releaseTaskPowerSaveBlocker,
@@ -84,18 +82,6 @@ let isProcessing = false;
 let maxConcurrentTasks = 3;
 let hasOpenAiWhisper = false;
 let activeTasksCount = 0;
-/** 执行中"受限引擎"(faster-whisper/funasr)任务数：混合引擎队列并发钳制用。 */
-let activeRestrictiveCount = 0;
-
-/** faster-whisper / funasr / qwen / fireRedAsr 共享单 sidecar/worker，需钳制有效并发为 1。 */
-function isRestrictiveEngine(engine: TranscriptionEngine): boolean {
-  return (
-    engine === 'fasterWhisper' ||
-    engine === 'funasr' ||
-    engine === 'qwen' ||
-    engine === 'fireRedAsr'
-  );
-}
 /** 最近一次 handleTask 的 event：resume 触发派发时复用 */
 let dispatchEvent: any = null;
 /** Dock/任务栏进度条目标窗口 */
@@ -460,29 +446,9 @@ async function processNextTasks(event) {
     return;
   }
 
-  // 混合引擎并发钳制：只要"执行中"或"待派发(可派发)"任务里含 faster-whisper/funasr，
-  // 有效并发钳为 1（共享单 sidecar/worker，避免显存争用与取消句柄相互覆盖）；
-  // 纯 builtin/localCli 队列遵循用户配置的并发。
-  let effectiveMax = maxConcurrentTasks;
-  try {
-    let hasRestrictive = activeRestrictiveCount > 0;
-    if (!hasRestrictive) {
-      for (const item of processingQueue) {
-        const runtime = projectRuntimes.get(item.projectId);
-        if (runtime?.paused || runtime?.cancelled) continue;
-        if (isRestrictiveEngine(resolveEngineIdForTask(item.formData))) {
-          hasRestrictive = true;
-          break;
-        }
-      }
-    }
-    if (hasRestrictive) effectiveMax = 1;
-  } catch {
-    // 解析引擎失败时回退到用户配置的并发
-  }
-
-  // 计算可以启动的新任务数量
-  const availableSlots = effectiveMax - activeTasksCount;
+  // 计算可以启动的新任务数量。ASR 单 runtime 的串行保护已下沉到 transcriptionRouter，
+  // 这里只按用户设置控制文件级流水线并发，避免纯翻译/翻译阶段被误钳成单线程。
+  const availableSlots = maxConcurrentTasks - activeTasksCount;
 
   if (availableSlots > 0) {
     const tasksToProcess = takeEligibleItems(availableSlots);
@@ -492,10 +458,8 @@ async function processNextTasks(event) {
       tasksToProcess.forEach(async (task) => {
         const runtime = ensureRuntime(task.projectId);
         const fileUuid = task.file?.uuid;
-        const taskEngine = resolveEngineIdForTask(task.formData);
         activeTasksCount++;
         runtime.active++;
-        if (isRestrictiveEngine(taskEngine)) activeRestrictiveCount++;
         if (fileUuid) runtime.activeFiles.add(fileUuid);
         try {
           const baseProvider = translationProviders.find(
@@ -528,7 +492,6 @@ async function processNextTasks(event) {
         } finally {
           activeTasksCount--;
           runtime.active--;
-          if (isRestrictiveEngine(taskEngine)) activeRestrictiveCount--;
           runtime.completed++;
           if (fileUuid) runtime.activeFiles.delete(fileUuid);
           finalizeProjectIfDrained(event, task.projectId);

--- a/main/helpers/transcriptionConcurrency.ts
+++ b/main/helpers/transcriptionConcurrency.ts
@@ -1,0 +1,34 @@
+import type { TranscriptionEngine } from '../../types/engine';
+
+const SERIALIZED_TRANSCRIPTION_ENGINES = new Set<TranscriptionEngine>([
+  'fasterWhisper',
+  'funasr',
+  'qwen',
+  'fireRedAsr',
+]);
+
+export function shouldSerializeTranscriptionEngine(
+  engine: TranscriptionEngine,
+): boolean {
+  return SERIALIZED_TRANSCRIPTION_ENGINES.has(engine);
+}
+
+export function createSerialTaskRunner() {
+  let queue: Promise<unknown> = Promise.resolve();
+
+  return async function runSerially<T>(task: () => Promise<T>): Promise<T> {
+    const previous = queue.catch(() => undefined);
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    queue = previous.then(() => gate);
+    await previous;
+    try {
+      return await task();
+    } finally {
+      release();
+    }
+  };
+}

--- a/main/helpers/transcriptionRouter.ts
+++ b/main/helpers/transcriptionRouter.ts
@@ -2,6 +2,12 @@ import { getEngineAdapterForTask } from './engines/registry';
 import { getTaskContext } from './taskContext';
 import type { TranscribeContext } from './engines/types';
 import type { TranscriptionEngine } from '../../types/engine';
+import {
+  createSerialTaskRunner,
+  shouldSerializeTranscriptionEngine,
+} from './transcriptionConcurrency';
+
+const runSerializedTranscription = createSerialTaskRunner();
 
 export async function routeTranscription(
   ctx: TranscribeContext,
@@ -16,9 +22,20 @@ export async function routeTranscription(
       `${adapter.displayName} is not available: ${status.message || status.state}`,
     );
   }
+  const transcribe = () =>
+    adapter.transcribe({
+      ...ctx,
+      signal: ctx.signal ?? getTaskContext()?.signal,
+    });
+
   // 取消信号统一在此从任务上下文注入，引擎以 ctx.signal 为准。
-  return adapter.transcribe({
-    ...ctx,
-    signal: ctx.signal ?? getTaskContext()?.signal,
-  });
+  // faster-whisper / sherpa 系共享单 runtime，只串行真正的 ASR 阶段；
+  // 音频提取和翻译仍由任务队列按 maxConcurrentTasks 并发执行。
+  if (shouldSerializeTranscriptionEngine(adapter.id)) {
+    return runSerializedTranscription(transcribe);
+  }
+
+  return transcribe();
 }
+
+export { shouldSerializeTranscriptionEngine } from './transcriptionConcurrency';

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -95,6 +95,10 @@ import {
   isSherpaEngineId,
   outcomeSupportsContextKnobs,
 } from '../main/helpers/engines/outcomePresets';
+import {
+  createSerialTaskRunner,
+  shouldSerializeTranscriptionEngine,
+} from '../main/helpers/transcriptionConcurrency';
 
 let passed = 0;
 let failed = 0;
@@ -1782,7 +1786,96 @@ eq(
   );
 }
 
-console.log(`\nengine unit tests: ${passed} passed, ${failed} failed`);
-if (failed > 0) {
-  process.exit(1);
+// --- transcriptionConcurrency: 仅串行共享 runtime 的 ASR 阶段 ---
+eq(
+  shouldSerializeTranscriptionEngine('builtin'),
+  false,
+  'concurrency: builtin transcriptions do not require router serialization',
+);
+eq(
+  shouldSerializeTranscriptionEngine('localCli'),
+  false,
+  'concurrency: local CLI transcriptions do not require router serialization',
+);
+eq(
+  shouldSerializeTranscriptionEngine('fasterWhisper'),
+  true,
+  'concurrency: faster-whisper transcriptions are serialized',
+);
+eq(
+  shouldSerializeTranscriptionEngine('funasr'),
+  true,
+  'concurrency: FunASR transcriptions are serialized',
+);
+eq(
+  shouldSerializeTranscriptionEngine('qwen'),
+  true,
+  'concurrency: Qwen transcriptions are serialized',
+);
+eq(
+  shouldSerializeTranscriptionEngine('fireRedAsr'),
+  true,
+  'concurrency: FireRed transcriptions are serialized',
+);
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
 }
+
+async function runAsyncTests(): Promise<void> {
+  const runSerially = createSerialTaskRunner();
+  const firstRelease = deferred();
+  const events: string[] = [];
+
+  const first = runSerially(async () => {
+    events.push('first:start');
+    await firstRelease.promise;
+    events.push('first:end');
+    return 'first';
+  });
+  const second = runSerially(async () => {
+    events.push('second:start');
+    events.push('second:end');
+    return 'second';
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  eq(
+    events,
+    ['first:start'],
+    'concurrency: queued serial task waits for the active task',
+  );
+  firstRelease.resolve();
+
+  eq(
+    await Promise.all([first, second]),
+    ['first', 'second'],
+    'concurrency: serial runner returns task results in order',
+  );
+  eq(
+    events,
+    ['first:start', 'first:end', 'second:start', 'second:end'],
+    'concurrency: serial runner does not overlap tasks',
+  );
+}
+
+runAsyncTests()
+  .then(() => {
+    console.log(`\nengine unit tests: ${passed} passed, ${failed} failed`);
+    if (failed > 0) {
+      process.exit(1);
+    }
+  })
+  .catch((error) => {
+    failed++;
+    console.error(error);
+    console.log(`\nengine unit tests: ${passed} passed, ${failed} failed`);
+    process.exit(1);
+  });


### PR DESCRIPTION
close #367

## 修改内容
- 移除任务队列层面对 faster-whisper / FunASR / Qwen / FireRed 的整文件串行钳制，让文件级任务重新按“最大并发任务数”派发。
- 新增转写阶段串行锁，仅串行共享单 runtime 的 ASR 调用，避免多个 faster-whisper / sherpa 系转写同时占用同一 sidecar / worker。
- 纯翻译任务不再因为保留了 transcriptionEngine 配置而被误判为需要单线程执行；生成+翻译任务的音频提取和翻译阶段也可以继续并行。
- 补充并发判定和串行锁行为的单元测试。

## 根因
原来的调度器只要发现执行中或待派发队列里存在 faster-whisper / FunASR / Qwen / FireRed，就把整批任务的有效并发数降为 1。这个保护范围过大，导致用户即使设置并发数为 5，提取、翻译以及 translateOnly 场景也只能一个个处理。

## 验证
- `npm run test:engines`
- `npm run check:i18n`
- `npm run build`