### PR TITLE
fix: 修复长静音后的字幕句子错位

### DIFF
--- a/main/helpers/subtitleSegmentation.ts
+++ b/main/helpers/subtitleSegmentation.ts
@@ -4,11 +4,11 @@
  * 上游 fork（buxuku/whisper.cpp）已在原生层提供：
  *   - `token_timestamps:true, max_len:0` → 逐 token 输出 `{ text, t0, t1, p }`（t0/t1 为毫秒）；
  *   - token 时间已做 **segment-aware 映射**：落在语音段内的 token 线性映射回原始时间轴，落在
- *     段间「人工静音」的 token 就近吸附到真实语音边界——于是**段间停顿天然以 token gap 体现**，
- *     不再需要 TS 侧用外部 VAD 把 token 贴回有声区间（旧 `retimeTokensToSpeech` 已删除）。
+ *     段间「人工静音」的 token 通常吸附到真实语音边界；原生层也会免费暴露本次转写使用的 VAD 段。
  *
- * 因此本模块只剩「成句」职责（与边界/停顿还原无关）：
+ * 本模块用同一组 VAD 段修正偶发的跨静音 token，再完成「成句」：
  *   tokensToTriples（毫秒 → [startStr,endStr,text]）
+ *     → clampTriplesToSpeechSegments（跨静音 token/run 收回真实语音段）
  *     → groupTokenCues（按 token gap / 句末标点 / 软切标点 / 长度上限成句；
  *       硬上限切分回溯到最近可断标点，避免孤立句尾词）
  *     → mergeShortCues（单字碎片并回相邻 cue）
@@ -441,51 +441,358 @@ export function vadSegmentsToSpeech(
     .sort((a, b) => a.start - b.start);
 }
 
-/** token 中点所属语音段索引：优先包含该中点的段，否则取距离最近的段。 */
-function segIndexForMid(mid: number, segs: SpeechSegment[]): number {
-  for (let i = 0; i < segs.length; i++) {
-    if (mid >= segs[i].start && mid <= segs[i].end) return i;
-  }
-  let best = 0;
-  let bestDist = Infinity;
-  for (let i = 0; i < segs.length; i++) {
-    const d = mid < segs[i].start ? segs[i].start - mid : mid - segs[i].end;
-    if (d < bestDist) {
-      bestDist = d;
-      best = i;
+const SPEECH_EDGE_EPSILON_SECONDS = 0.08;
+
+interface TokenSpeechContext {
+  prevIndex: number | null;
+  nextIndex: number | null;
+  bridgeTargetIndex: number | null;
+}
+
+interface ParsedSpeechToken {
+  start: number | null;
+  end: number | null;
+  text: string;
+  raw: TokenTriple;
+}
+
+/** token 与重叠最大的语音段交集；无重叠返回 null。 */
+function bestTokenOverlap(
+  start: number,
+  end: number,
+  segments: SpeechSegment[],
+): { index: number; start: number; end: number } | null {
+  let best: { index: number; start: number; end: number } | null = null;
+  let bestDuration = 0;
+  for (let i = 0; i < segments.length; i += 1) {
+    const segment = segments[i];
+    if (segment.start >= end) break;
+    if (segment.end <= start) continue;
+    const overlapStart = Math.max(start, segment.start);
+    const overlapEnd = Math.min(end, segment.end);
+    const duration = overlapEnd - overlapStart;
+    if (duration > bestDuration) {
+      bestDuration = duration;
+      best = { index: i, start: overlapStart, end: overlapEnd };
     }
   }
   return best;
 }
 
+/** 零时长 token 所在语音段；不在任何段内返回 null。 */
+function segmentIndexForPoint(
+  point: number,
+  segments: SpeechSegment[],
+): number | null {
+  const index = segments.findIndex(
+    (segment) => point >= segment.start && point <= segment.end,
+  );
+  return index >= 0 ? index : null;
+}
+
 /**
- * 用 whisper **内部 VAD 段**（addon 已免费暴露，非外部二次 VAD）把逐 token 时间「吸附」回真实语音：
- * 每个 token 按中点归属到最近的语音段，并把它的 [start,end] 夹在该段 [start,end] 内。
+ * 判断 token 是否横跨一整段真实静音。
+ *
+ * whisper.cpp 开 VAD 时，静音后的首 token 可能被扩展成
+ * `[前段末点, 后段起点/段内]`。这种 token 的中点没有语义，按最近边界会把句首误吸回前句；
+ * 只要内容 token 覆盖了完整的 >0.5s VAD gap，就明确归到后段。
+ */
+function bridgeTargetIndex(
+  start: number,
+  end: number,
+  segments: SpeechSegment[],
+): number | null {
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const previous = segments[i];
+    const next = segments[i + 1];
+    if (next.start - previous.end <= DEFAULTS.maxGapSeconds) continue;
+    if (
+      start >= previous.end - SPEECH_EDGE_EPSILON_SECONDS &&
+      start <= previous.end + SPEECH_EDGE_EPSILON_SECONDS &&
+      end >= next.start - SPEECH_EDGE_EPSILON_SECONDS
+    ) {
+      return i + 1;
+    }
+  }
+  return null;
+}
+
+function tokenSpeechContext(
+  start: number,
+  end: number,
+  segments: SpeechSegment[],
+): TokenSpeechContext {
+  const bridge = bridgeTargetIndex(start, end, segments);
+  if (bridge !== null) {
+    return {
+      prevIndex: bridge - 1,
+      nextIndex: bridge,
+      bridgeTargetIndex: bridge,
+    };
+  }
+
+  let prevIndex: number | null = null;
+  for (let i = 0; i < segments.length; i += 1) {
+    if (segments[i].end <= start + SPEECH_EDGE_EPSILON_SECONDS) {
+      prevIndex = i;
+    }
+  }
+  const nextIndex = segments.findIndex(
+    (segment) => segment.start >= end - SPEECH_EDGE_EPSILON_SECONDS,
+  );
+  return {
+    prevIndex,
+    nextIndex: nextIndex >= 0 ? nextIndex : null,
+    bridgeTargetIndex: null,
+  };
+}
+
+function sameTokenSpeechContext(
+  left: TokenSpeechContext,
+  right: TokenSpeechContext,
+): boolean {
+  return (
+    left.prevIndex === right.prevIndex && left.nextIndex === right.nextIndex
+  );
+}
+
+/**
+ * 把同一静音区里的连续内容 token 收进目标语音段。
+ * - 前向 run：去掉线性摊时产生的假空隙，紧凑排列；目标段装不下时等比压缩。
+ * - 后向 run：保持原有兼容语义，全部收敛到前段末点，交给 group 与前文合并。
+ */
+function packFloatingRun(
+  info: ParsedSpeechToken[],
+  from: number,
+  to: number,
+  window: SpeechSegment,
+  forward: boolean,
+  segments: SpeechSegment[],
+): TokenTriple[] {
+  if (!forward) {
+    return info
+      .slice(from, to)
+      .map((token) => [
+        formatTime(window.end),
+        formatTime(window.end),
+        token.text,
+      ]);
+  }
+
+  const durations = info.slice(from, to).map((token) => {
+    const start = token.start as number;
+    const end = token.end as number;
+    const rawDuration = Math.max(0, end - start);
+    if (bridgeTargetIndex(start, end, segments) === null) {
+      return Math.max(0.08, rawDuration);
+    }
+    let crossedSilence = 0;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const gapStart = segments[i].end;
+      const gapEnd = segments[i + 1].start;
+      if (gapEnd <= start || gapStart >= end) continue;
+      crossedSilence += Math.min(end, gapEnd) - Math.max(start, gapStart);
+    }
+    // 横跨完整静音的首 token 只保留去掉静音后的有效时长；完全贴边时留 80ms，
+    // 避免它单独落成零时长字幕，同时不占满整个后段。
+    return Math.max(0.08, rawDuration - crossedSilence);
+  });
+  const totalDuration = durations.reduce((sum, duration) => sum + duration, 0);
+  const targetDuration = Math.max(0, window.end - window.start);
+  const scale =
+    totalDuration > targetDuration && totalDuration > 0
+      ? targetDuration / totalDuration
+      : 1;
+  const packedDuration = totalDuration * scale;
+  let cursor = forward ? window.start : window.end - packedDuration;
+
+  return info.slice(from, to).map((token, index): TokenTriple => {
+    const start = cursor;
+    cursor += durations[index] * scale;
+    return [formatTime(start), formatTime(cursor), token.text];
+  });
+}
+
+/**
+ * 用 whisper **内部 VAD 段**（addon 已免费暴露，非外部二次 VAD）把逐 token 时间收进真实语音：
+ * - 已与语音段重叠的 token 收敛到最大重叠段；
+ * - 横跨完整静音的桥接 token 明确归到后段；
+ * - 同一静音区里的连续内容 token 作为一个 run 整体判向并紧凑放入同一语音段。
  *
  * 解决的问题：whisper 的 token 级时间戳是「按 voice_length 把整段时长摊给 token」的启发式，
  * 当某个转写 segment 跨越了一段人工静音（VAD 删除的静音）时，medium 这类模型会把 token 时间
- * **连续地摊过静音**（实测 medium 在 21.5→25.1s 静音处最大 token 间隔仅 600ms，字幕直接糊穿静音；
- * 而 tiny 恰好摊出 3.67s 间隔才躲过）。夹紧后：静音前 token≤段尾、静音后 token≥段首，groupTokenCues
- * 依据由此产生的真实间隔自然断句，字幕不再压在静音上——且与模型无关（medium/tiny 一致）。
+ * **连续地摊过静音**。逐 token 按中点选最近段会从静音中间劈开同一句，形成 #372 的
+ * 「上一句后半 + 下一句前半」滚动错位；run 级归属恢复真实间隔，也不会把句尾拖尾字一律前移。
  */
 export function clampTriplesToSpeechSegments(
   triples: TokenTriple[],
   segments: SpeechSegment[],
 ): TokenTriple[] {
   if (!Array.isArray(triples) || !segments?.length) return triples;
-  const segs = [...segments].sort((a, b) => a.start - b.start);
-  return triples.map((triple): TokenTriple => {
-    const st = parseTime(triple?.[0]);
-    const en = parseTime(triple?.[1]);
-    const text = triple?.[2] ?? '';
-    if (st === null || en === null)
-      return [triple?.[0] ?? '', triple?.[1] ?? '', text];
-    const mid = (st + en) / 2;
-    const seg = segs[segIndexForMid(mid, segs)];
-    const cs = Math.min(Math.max(st, seg.start), seg.end);
-    const ce = Math.max(cs, Math.min(Math.max(en, seg.start), seg.end));
-    return [formatTime(cs), formatTime(ce), text];
-  });
+  const segs = [...segments]
+    .filter(
+      (segment) =>
+        Number.isFinite(segment.start) &&
+        Number.isFinite(segment.end) &&
+        segment.end > segment.start,
+    )
+    .sort((a, b) => a.start - b.start);
+  if (segs.length === 0) return triples;
+
+  const info: ParsedSpeechToken[] = triples.map((triple) => ({
+    start: parseTime(triple?.[0]),
+    end: parseTime(triple?.[1]),
+    text: triple?.[2] ?? '',
+    raw: triple,
+  }));
+  const out: TokenTriple[] = triples.map((triple) => triple);
+
+  const contextAt = (index: number): TokenSpeechContext | null => {
+    const token = info[index];
+    if (token.start === null || token.end === null) return null;
+    return tokenSpeechContext(token.start, token.end, segs);
+  };
+  const isFloatingContent = (index: number): boolean => {
+    const token = info[index];
+    if (token.start === null || token.end === null) return false;
+    const trimmed = token.text.trim();
+    if (!trimmed || PUNCT_ONLY.test(trimmed)) return false;
+    const context = contextAt(index);
+    if (context?.bridgeTargetIndex !== null) return true;
+    if (token.end > token.start) {
+      return bestTokenOverlap(token.start, token.end, segs) === null;
+    }
+    return segmentIndexForPoint(token.start, segs) === null;
+  };
+
+  // 记录每个语音段按 token 顺序已经占用的末点；同一段可能接收多个被空白/独立标点
+  // 隔开的 forward run，也可能已有锚定 token，后续 run 不能再从段首开始与它们重叠。
+  const outputCursorBySegment = new Map<number, number>();
+  const recordOutputCursor = (segmentIndex: number, end: number) => {
+    outputCursorBySegment.set(
+      segmentIndex,
+      Math.max(outputCursorBySegment.get(segmentIndex) ?? 0, end),
+    );
+  };
+  let index = 0;
+  while (index < info.length) {
+    const token = info[index];
+    if (token.start === null || token.end === null) {
+      out[index] = token.raw;
+      index += 1;
+      continue;
+    }
+
+    if (!isFloatingContent(index)) {
+      if (token.end > token.start) {
+        const overlap = bestTokenOverlap(token.start, token.end, segs);
+        out[index] = overlap
+          ? [formatTime(overlap.start), formatTime(overlap.end), token.text]
+          : token.raw;
+        if (overlap) recordOutputCursor(overlap.index, overlap.end);
+      } else {
+        out[index] = token.raw;
+        const pointSegment = segmentIndexForPoint(token.start, segs);
+        if (pointSegment !== null) {
+          recordOutputCursor(pointSegment, token.start);
+        }
+      }
+      index += 1;
+      continue;
+    }
+
+    const context = contextAt(index) as TokenSpeechContext;
+    let runEnd = index + 1;
+    while (
+      runEnd < info.length &&
+      !SENTENCE_END.test(info[runEnd - 1].text.trim()) &&
+      isFloatingContent(runEnd) &&
+      sameTokenSpeechContext(context, contextAt(runEnd) as TokenSpeechContext)
+    ) {
+      runEnd += 1;
+    }
+
+    const first = info[index];
+    const last = info[runEnd - 1];
+    const previous =
+      context.prevIndex !== null ? segs[context.prevIndex] : null;
+    const next = context.nextIndex !== null ? segs[context.nextIndex] : null;
+    const gapToPrevious = previous
+      ? Math.max(0, first.start! - previous.end)
+      : Number.POSITIVE_INFINITY;
+    const gapToNext = next
+      ? Math.max(0, next.start - last.end!)
+      : Number.POSITIVE_INFINITY;
+    const forward =
+      context.bridgeTargetIndex !== null || gapToNext <= gapToPrevious;
+    const target = forward ? next : previous;
+    const targetIndex = forward ? context.nextIndex : context.prevIndex;
+
+    if (target) {
+      let window = target;
+      if (forward) {
+        let windowStart = Math.max(
+          target.start,
+          targetIndex !== null
+            ? (outputCursorBySegment.get(targetIndex) ?? target.start)
+            : target.start,
+        );
+        const previousOutputEnd =
+          index > 0 ? parseTime(out[index - 1]?.[1]) : null;
+        if (previousOutputEnd !== null && previousOutputEnd > target.start) {
+          windowStart = Math.min(
+            Math.max(windowStart, previousOutputEnd),
+            target.end,
+          );
+        }
+
+        // 不占用后续已锚定 token 的时间，否则前移 run 可能越过后续 token，
+        // 让 group 产出倒序或互相重叠的 cue。
+        let windowEnd = target.end;
+        for (let i = runEnd; i < info.length; i += 1) {
+          const follower = info[i];
+          if (follower.start === null || follower.end === null) continue;
+          if (follower.start >= target.end) break;
+          if (isFloatingContent(i)) continue;
+          const overlapStart = Math.max(follower.start, target.start);
+          const overlapEnd = Math.min(follower.end, target.end);
+          if (
+            overlapEnd > overlapStart ||
+            (follower.start === follower.end &&
+              follower.start >= target.start &&
+              follower.start <= target.end)
+          ) {
+            windowEnd = Math.max(
+              windowStart,
+              Math.min(windowEnd, overlapStart),
+            );
+            break;
+          }
+        }
+        window = { start: windowStart, end: windowEnd };
+      }
+      const packed = packFloatingRun(
+        info,
+        index,
+        runEnd,
+        window,
+        forward,
+        segs,
+      );
+      for (let i = index; i < runEnd; i += 1) {
+        out[i] = packed[i - index];
+      }
+      if (forward && targetIndex !== null && packed.length > 0) {
+        const packedEnd = parseTime(packed[packed.length - 1][1]);
+        if (packedEnd !== null) {
+          recordOutputCursor(targetIndex, packedEnd);
+        }
+      }
+    }
+    index = runEnd;
+  }
+
+  return out;
 }
 
 export interface ClampDominantOptions {

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -1269,7 +1269,7 @@ const T = (a: string, b: string, c: string): TokenTriple => [a, b, c];
     { start: 19.5, end: 21.51 },
     { start: 25.11, end: 27.14 },
   ];
-  // token 落在语音段内 → 原样保留；落在段间静音 → 就近吸附到边界（不再压在静音上）
+  // token 落在语音段内 → 原样保留；落在段间静音且靠前段 → 收敛到前段末点。
   eq(
     clampTriplesToSpeechSegments(
       [
@@ -1284,7 +1284,7 @@ const T = (a: string, b: string, c: string): TokenTriple => [a, b, c];
       ['00:00:21,510', '00:00:21,510', '度'],
       ['00:00:26,000', '00:00:26,500', '請'],
     ],
-    'clampTriplesToSpeechSegments: silence token snaps to nearest boundary',
+    'clampTriplesToSpeechSegments: silence tail token snaps to previous boundary',
   );
   // 夹紧后 group：静音前后被自然间隔切成两条，字幕不糊穿静音
   eq(
@@ -1300,6 +1300,198 @@ const T = (a: string, b: string, c: string): TokenTriple => [a, b, c];
     ).length >= 2,
     true,
     'clamp+group: silence yields a cue split (no spill across silence)',
+  );
+  // #372 真实公开视频片段：静音后首字「我」的 token 被 whisper 扩展为
+  // [上一段末点, 下一段起点]，逐 token 中点就近会把「我」误吸回上一句。
+  // 桥接完整静音的内容 token 应归到后段，恢复「通过」/「我这个」的句首归属。
+  eq(
+    groupTokenCues(
+      clampTriplesToSpeechSegments(
+        [
+          T('00:00:06,130', '00:00:06,400', '通过'),
+          T('00:00:06,400', '00:00:23,700', '我'),
+          T('00:00:23,700', '00:00:24,030', '这个'),
+        ],
+        [
+          { start: 4.7, end: 6.44 },
+          { start: 23.7, end: 25.83 },
+        ],
+      ),
+    ).map((cue) => cue[2]),
+    ['通过', '我这个'],
+    'clamp+group: full-gap bridge token belongs to following speech segment (#372)',
+  );
+  // #372 严格回归：同一句的连续 token 被线性摊进数秒静音时，必须按整个 run
+  // 归到同一语音段，不能从静音中点劈成「上一句后半 + 下一句前半」。
+  const issue372Speech = [
+    { start: 0, end: 2 },
+    { start: 7, end: 9 },
+    { start: 15, end: 17 },
+  ];
+  const issue372Input = [
+    T('00:00:00,200', '00:00:01,800', '语句1。'),
+    T('00:00:02,100', '00:00:02,800', '语句2前'),
+    T('00:00:04,200', '00:00:04,400', '中'),
+    T('00:00:06,700', '00:00:06,950', '后'),
+    T('00:00:07,600', '00:00:08,700', '收尾。'),
+    T('00:00:09,100', '00:00:09,800', '语句3前'),
+    T('00:00:12,200', '00:00:12,400', '中'),
+    T('00:00:14,700', '00:00:14,950', '后'),
+    T('00:00:15,600', '00:00:16,700', '收尾。'),
+  ];
+  const issue372Cues = groupTokenCues(
+    clampTriplesToSpeechSegments(issue372Input, issue372Speech),
+  );
+  const issue372Seconds = (value: string) => {
+    const parts = value.replace(',', '.').split(':').map(Number);
+    return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  };
+  eq(
+    issue372Cues.map((cue) => cue[2]),
+    ['语句1。', '语句2前中后收尾。', '语句3前中后收尾。'],
+    'clamp+group: long-silence token runs keep complete sentences (#372)',
+  );
+  eq(
+    issue372Cues.map((cue) => [cue[0], cue[1]]),
+    [
+      ['00:00:00,200', '00:00:01,800'],
+      ['00:00:07,000', '00:00:08,700'],
+      ['00:00:15,000', '00:00:16,700'],
+    ],
+    'clamp+group: long-silence cues stay inside their speech segments (#372)',
+  );
+  eq(
+    issue372Cues.every(
+      (cue) => issue372Seconds(cue[1]) > issue372Seconds(cue[0]),
+    ),
+    true,
+    'clamp+group: long-silence fix emits no zero-duration cue (#372)',
+  );
+  eq(
+    issue372Cues.map((cue) => cue[2]).join(''),
+    issue372Input.map((token) => token[2]).join(''),
+    'clamp+group: long-silence fix preserves every token exactly once (#372)',
+  );
+  // 反向护栏：靠近前段的句尾拖尾字应整体回填前段，不能因为统一前移而变成下一句开头。
+  eq(
+    groupTokenCues(
+      clampTriplesToSpeechSegments(
+        [
+          T('00:00:49,850', '00:00:49,916', '广'),
+          T('00:00:50,090', '00:00:50,400', '泛'),
+          T('00:00:53,862', '00:00:54,200', '请'),
+        ],
+        [
+          { start: 44.96, end: 49.916 },
+          { start: 53.862, end: 56.76 },
+        ],
+      ),
+    ).map((cue) => cue[2]),
+    ['广泛', '请'],
+    'clamp+group: trailing token run stays with previous speech segment',
+  );
+  // 同一静音区同时包含前句尾与后句首时，句末标点必须切断 floating run；
+  // 否则整段按后句首的位置前移，会把「结尾。」从前句剥离成后段孤条。
+  eq(
+    groupTokenCues(
+      clampTriplesToSpeechSegments(
+        [
+          T('00:00:01,000', '00:00:01,900', '前句'),
+          T('00:00:02,100', '00:00:02,300', '结尾。'),
+          T('00:00:06,800', '00:00:06,950', '后句开头'),
+          T('00:00:07,200', '00:00:08,000', '后句'),
+        ],
+        [
+          { start: 0, end: 2 },
+          { start: 7, end: 9 },
+        ],
+      ),
+    ).map((cue) => cue[2]),
+    ['前句结尾。', '后句开头后句'],
+    'clamp+group: sentence end separates opposite floating runs in one gap',
+  );
+  // 只有起点贴着前段末点的 token 才是原生 VAD 产生的桥接 token；
+  // 从前段内部开始的长 token 应按实际最大重叠留在前段。
+  eq(
+    clampTriplesToSpeechSegments(
+      [T('00:00:00,500', '00:00:07,010', '前句长词')],
+      [
+        { start: 0, end: 2 },
+        { start: 7, end: 9 },
+      ],
+    ),
+    [['00:00:00,500', '00:00:02,000', '前句长词']],
+    'clamp: only an edge-aligned token can bridge a full VAD gap',
+  );
+  // 前向 run 必须在后续已锚定 token 之前收尾，不能占满目标语音段后再让时间倒退。
+  eq(
+    groupTokenCues(
+      clampTriplesToSpeechSegments(
+        [
+          T('00:00:01,000', '00:00:01,900', '前。'),
+          T('00:00:04,000', '00:00:05,000', '后句前'),
+          T('00:00:06,800', '00:00:06,900', '结束。'),
+          T('00:00:07,100', '00:00:07,500', '下一句'),
+        ],
+        [
+          { start: 0, end: 2 },
+          { start: 7, end: 9 },
+        ],
+      ),
+    ),
+    [
+      ['00:00:01,000', '00:00:01,900', '前。'],
+      ['00:00:07,000', '00:00:07,100', '后句前结束。'],
+      ['00:00:07,100', '00:00:07,500', '下一句'],
+    ],
+    'clamp+group: forward run reserves time for following anchored token',
+  );
+  // 独立标点会打断两个 forward run；第二个 run 仍须承接第一个的末点，
+  // 不能因为紧邻项是原样保留的标点就从目标段起点重新开始。
+  eq(
+    groupTokenCues(
+      clampTriplesToSpeechSegments(
+        [
+          T('00:00:01,000', '00:00:01,900', '前。'),
+          T('00:00:04,000', '00:00:05,000', '后句'),
+          T('00:00:05,100', '00:00:05,200', '。'),
+          T('00:00:06,800', '00:00:06,900', '下一句前'),
+          T('00:00:07,500', '00:00:08,000', '下一句后'),
+        ],
+        [
+          { start: 0, end: 2 },
+          { start: 7, end: 9 },
+        ],
+      ),
+    ),
+    [
+      ['00:00:01,000', '00:00:01,900', '前。'],
+      ['00:00:07,000', '00:00:07,500', '后句。'],
+      ['00:00:07,500', '00:00:08,000', '下一句前下一句后'],
+    ],
+    'clamp+group: punctuation-separated forward runs keep a monotonic cursor',
+  );
+  // 零时长内容 run 前移到后段起点后，应和后续真实 token 合成非零时长字幕。
+  eq(
+    groupTokenCues(
+      clampTriplesToSpeechSegments(
+        [
+          T('00:00:36,000', '00:00:36,956', '号'),
+          T('00:00:41,400', '00:00:41,400', '人'),
+          T('00:00:41,400', '00:00:41,400', '工'),
+          T('00:00:41,926', '00:00:43,400', '正在'),
+        ],
+        [
+          { start: 30, end: 36.956 },
+          { start: 41.926, end: 44.96 },
+        ],
+      ),
+    ),
+    [
+      ['00:00:36,000', '00:00:36,956', '号'],
+      ['00:00:41,926', '00:00:43,400', '人工正在'],
+    ],
+    'clamp+group: zero-duration run joins following speech without an orphan cue',
   );
   // 无段信息（VAD 关 / 旧加速包）→ 恒等变换
   eq(


### PR DESCRIPTION
## 问题

#372 中，开启 whisper.cpp 内部 VAD 后，跨越长静音的 token 会被逐个按中点吸附到最近语音段。模型把同一句的 token 线性摊进静音时，这会从静音中间拆开句子，形成“上一句后半 + 下一句前半”的滚动错位。

公开视频样本里，静音后的首字“我”被标成 `6.400s → 23.700s`，完整横跨 `6.440s → 23.700s` 的 VAD 静音。旧逻辑会把它归入前句，输出“通过我”/“这个……”而不是“通过”/“我这个……”。

## 修改

- 对横跨完整 VAD 静音、且起点贴近前段末点的桥接 token，明确归入后段。
- 对同一静音区的连续内容 token 按 run 整体判向，避免逐 token 从中间劈开同一句。
- 用句末标点切断分别属于前后两句的 floating run，同时保留靠近前段的句尾拖尾语义。
- 前移 run 时维护目标语音段的单调游标，并为后续已锚定 token 预留时间，避免字幕倒序或重叠。
- 同步更新模块说明，补齐真实样本与多种边界回归测试。

## 实测

- 使用 issue 评论中的 Bilibili 公共视频截取 `13:10 → 13:45` 音频复现；修复后“我”归入静音后的字幕，句子边界恢复正确。
- 视频和音频仅用于本地复现，没有提交到仓库。

## 验证

- `yarn test:engines`：655 passed，0 failed
- `yarn test:translate-parser`：14 passed
- `yarn test:structured-output`：16 passed，0 failed
- `yarn test:translation-cancel`：6 passed，0 failed
- `yarn check:i18n`：通过
- `npx prettier --check main/helpers/subtitleSegmentation.ts scripts/test-engine-units.ts`：通过
- `git diff --check`：通过
- `yarn build`：通过

说明：当前 `upstream/main` 的 CI 配置了 `yarn test:dubbing`，但 `package.json` 尚无该脚本；本 PR 未扩大范围修改这一上游现状。

Closes #372
