### PR TITLE
ci: dubbing 单测步骤改为 --if-present，修复 main 恒红

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,11 @@ jobs:
       - name: Unit tests (translation cancel)
         run: yarn test:translation-cancel
 
+      # 配音功能与 test:dubbing 脚本随 3.4.0 开发分支引入，尚未合入 main；
+      # 用 --if-present 让脚本存在才执行，避免 workflow 引用未合并脚本导致 main 恒红，
+      # 配音分支合入后本步骤自动生效、无需改 workflow。
       - name: Unit tests (dubbing)
-        run: yarn test:dubbing
+        run: npm run test:dubbing --if-present
 
       - name: Compile application (renderer + main)
         run: yarn build


### PR DESCRIPTION
## 问题

#373 引入 CI workflow 时写入了 `yarn test:dubbing` 步骤，但 `test:dubbing` 脚本随配音功能仍在 3.4.0 开发分支、尚未合入 main。结果 main 与所有 PR（如 #379）的 App checks 在该步骤恒定失败，其后的 `yarn build` 从未执行，CI 形同虚设。

## 修改

- `Unit tests (dubbing)` 步骤由 `yarn test:dubbing` 改为 `npm run test:dubbing --if-present`：脚本不存在时静默跳过（exit 0），存在则正常执行。
- 配音功能合入 main 后，该步骤自动开始跑 dubbing 单测，无需再改 workflow。

## 验证

- `node -e "require('js-yaml').load(...)"`：workflow YAML 语法有效。
- 在 main 检出（无 `test:dubbing` 脚本）执行 `npm run test:dubbing --if-present` → exit 0，静默跳过。
- 在含配音功能的开发分支执行同命令 → 正常运行，137 passed, 0 failed。
- 本 PR 自身的 CI 运行即为端到端验证：App checks 应首次通过全部步骤（含 build）。