### PR TITLE
修复 faster-whisper 残缺模型导致的转写异常

### DIFF
--- a/main/helpers/download/resumeIntegrity.ts
+++ b/main/helpers/download/resumeIntegrity.ts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+
+export interface PreparedDownloadTarget {
+  complete: boolean;
+  startByte: number;
+}
+
+/**
+ * 按远端声明大小整理最终文件和续传临时文件。
+ * 旧版本留下的短最终文件会转为 .download 继续下载；超长文件会被丢弃重下。
+ */
+export function prepareDownloadTarget(
+  destPath: string,
+  tempPath: string,
+  expectedSize: number,
+): PreparedDownloadTarget {
+  if (fs.existsSync(destPath)) {
+    const actualSize = fs.statSync(destPath).size;
+    if (actualSize === expectedSize) {
+      if (fs.existsSync(tempPath)) fs.rmSync(tempPath, { force: true });
+      return { complete: true, startByte: 0 };
+    }
+
+    if (
+      actualSize > 0 &&
+      actualSize < expectedSize &&
+      !fs.existsSync(tempPath)
+    ) {
+      fs.renameSync(destPath, tempPath);
+    } else {
+      fs.rmSync(destPath, { force: true });
+    }
+  }
+
+  if (!fs.existsSync(tempPath)) return { complete: false, startByte: 0 };
+
+  const tempSize = fs.statSync(tempPath).size;
+  if (tempSize === expectedSize) {
+    fs.renameSync(tempPath, destPath);
+    return { complete: true, startByte: 0 };
+  }
+  if (tempSize > expectedSize) {
+    fs.rmSync(tempPath, { force: true });
+    return { complete: false, startByte: 0 };
+  }
+  return { complete: false, startByte: tempSize };
+}
+
+export function assertFileSize(
+  filePath: string,
+  expectedSize: number,
+  label = filePath,
+): void {
+  const actualSize = fs.existsSync(filePath) ? fs.statSync(filePath).size : -1;
+  if (actualSize !== expectedSize) {
+    throw new Error(
+      `${label} size mismatch: got ${actualSize}, expected ${expectedSize}`,
+    );
+  }
+}
+
+export type DownloadResponseDisposition = 'accept' | 'restart';
+
+/** 校验单连接续传响应，避免服务端忽略 Range 后把完整响应追加到临时文件。 */
+export function validateDownloadResponse(
+  statusCode: number,
+  contentRange: string | undefined,
+  startByte: number,
+  expectedSize: number,
+): DownloadResponseDisposition {
+  if (startByte > 0 && statusCode === 200) return 'restart';
+  if (statusCode !== 200 && statusCode !== 206) {
+    throw new Error(`Unexpected download status ${statusCode}`);
+  }
+  if (startByte > 0 && statusCode !== 206) {
+    throw new Error(`Expected partial response, got ${statusCode}`);
+  }
+
+  if (statusCode === 206) {
+    const match = contentRange?.match(/^bytes (\d+)-(\d+)\/(\d+)$/i);
+    if (!match) throw new Error('Invalid Content-Range response');
+    const rangeStart = Number(match[1]);
+    const rangeEnd = Number(match[2]);
+    const total = Number(match[3]);
+    if (
+      rangeStart !== startByte ||
+      rangeEnd < rangeStart ||
+      rangeEnd >= total ||
+      total !== expectedSize
+    ) {
+      throw new Error(
+        `Content-Range mismatch: got ${contentRange}, expected bytes ${startByte}-*/${expectedSize}`,
+      );
+    }
+  }
+
+  return 'accept';
+}

--- a/main/helpers/engines/fasterWhisperEngine.ts
+++ b/main/helpers/engines/fasterWhisperEngine.ts
@@ -174,7 +174,7 @@ async function transcribeFasterWhisper(
   if (!modelSnapshotDir) {
     if (modelInspection.incompleteSnapshotDir) {
       throw new Error(
-        `faster-whisper model "${modelId}" is incomplete (${modelInspection.issues.join(', ')}). Delete it and download it again from Resource Hub > Models.`,
+        `faster-whisper model "${modelId}" is incomplete (${modelInspection.issues.join(', ')}). Download it again from Resource Hub > Models to repair the missing files; deleting it first is not required.`,
       );
     }
     throw new Error(
@@ -182,7 +182,9 @@ async function transcribeFasterWhisper(
     );
   }
   const configuredDevice = (settings.fasterWhisperDevice || 'auto') as
-    'auto' | 'cpu' | 'cuda';
+    | 'auto'
+    | 'cpu'
+    | 'cuda';
   // device 逐次尝试注入，便于 CUDA 运行库缺失时回退 CPU 重试；其余参数对各设备一致。
   const baseParams = {
     engine: 'faster_whisper',

--- a/main/helpers/engines/fasterWhisperEngine.ts
+++ b/main/helpers/engines/fasterWhisperEngine.ts
@@ -8,6 +8,7 @@ import {
 } from '../pythonRuntime/paths';
 import {
   getFasterWhisperModelsPath,
+  inspectCt2ModelSnapshot,
   resolveCt2ModelSnapshotDir,
 } from '../modelCatalog';
 import { formatSrtContent } from '../fileUtils';
@@ -168,16 +169,20 @@ async function transcribeFasterWhisper(
   }
 
   const modelId = toFasterWhisperModel(model);
-  const modelSnapshotDir = resolveCt2ModelSnapshotDir(modelId);
+  const modelInspection = inspectCt2ModelSnapshot(modelId);
+  const modelSnapshotDir = modelInspection.snapshotDir;
   if (!modelSnapshotDir) {
+    if (modelInspection.incompleteSnapshotDir) {
+      throw new Error(
+        `faster-whisper model "${modelId}" is incomplete (${modelInspection.issues.join(', ')}). Delete it and download it again from Resource Hub > Models.`,
+      );
+    }
     throw new Error(
       `faster-whisper model "${modelId}" not found in ${getFasterWhisperModelsPath()}. Download it from Resource Hub > Models.`,
     );
   }
   const configuredDevice = (settings.fasterWhisperDevice || 'auto') as
-    | 'auto'
-    | 'cpu'
-    | 'cuda';
+    'auto' | 'cpu' | 'cuda';
   // device 逐次尝试注入，便于 CUDA 运行库缺失时回退 CPU 重试；其余参数对各设备一致。
   const baseParams = {
     engine: 'faster_whisper',

--- a/main/helpers/fasterWhisperModelDownloader.ts
+++ b/main/helpers/fasterWhisperModelDownloader.ts
@@ -16,7 +16,13 @@ import {
   downloadFileParallel,
   RangeNotSupportedError,
 } from './download/parallelDownloader';
+import {
+  assertFileSize,
+  prepareDownloadTarget,
+  validateDownloadResponse,
+} from './download/resumeIntegrity';
 import { getHfHost as resolveHfHost } from './config/downloadConfig';
+import { validateCt2ModelSnapshot } from './modelImport';
 
 interface HfTreeEntry {
   path: string;
@@ -275,35 +281,28 @@ export class FasterWhisperModelDownloader {
       error: undefined,
     });
 
+    // 进度和续传位置一律从磁盘实况重建，避免状态文件与残留文件不一致时
+    // 重复计数或跳过未完成文件。
     let downloadedBytes = 0;
-    let startFileIndex = 0;
-    const existingState = readDownloadState();
-    if (
-      existingState &&
-      existingState.modelId === modelId &&
-      existingState.revision === revision &&
-      existingState.source === source
-    ) {
-      downloadedBytes = existingState.downloaded;
-      startFileIndex = existingState.fileIndex;
-    }
 
     try {
-      for (let i = startFileIndex; i < plannedFiles.length; i++) {
+      for (let i = 0; i < plannedFiles.length; i++) {
         const file = plannedFiles[i];
         fs.mkdirSync(path.dirname(file.destPath), { recursive: true });
 
         const url = `${base}/${repoId}/resolve/${revision}/${file.path}`;
         const tempPath = `${file.destPath}.download`;
-        let startByte = 0;
-        if (fs.existsSync(file.destPath)) {
+        const prepared = prepareDownloadTarget(
+          file.destPath,
+          tempPath,
+          file.size,
+        );
+        if (prepared.complete) {
           downloadedBytes += file.size;
           this.updateProgress({ downloaded: downloadedBytes });
           continue;
         }
-        if (fs.existsSync(tempPath)) {
-          startByte = fs.statSync(tempPath).size;
-        }
+        const startByte = prepared.startByte;
 
         saveDownloadState({
           modelId,
@@ -337,11 +336,17 @@ export class FasterWhisperModelDownloader {
               },
               log: (message, level) => logMessage(message, level),
             });
+            assertFileSize(file.destPath, file.size, file.path);
             usedParallel = true;
           } catch (error) {
             const message =
               error instanceof Error ? error.message : String(error);
             if (message === 'Download cancelled') throw error;
+            // 并行下载可能已按服务端探测大小落盘，但仍与 Hub tree 声明不符；
+            // 回退单连接前清掉该最终文件，避免 Windows rename 冲突。
+            if (fs.existsSync(file.destPath)) {
+              fs.rmSync(file.destPath, { force: true });
+            }
             logMessage(
               `CT2 ${file.path} parallel download fallback (${message})`,
               error instanceof RangeNotSupportedError ? 'info' : 'warning',
@@ -359,10 +364,25 @@ export class FasterWhisperModelDownloader {
             totalBytes,
             file.size,
           );
+          assertFileSize(tempPath, file.size, file.path);
+          if (fs.existsSync(file.destPath)) {
+            fs.rmSync(file.destPath, { force: true });
+          }
           fs.renameSync(tempPath, file.destPath);
         }
-        downloadedBytes += file.size - startByte;
+        assertFileSize(file.destPath, file.size, file.path);
+        downloadedBytes += file.size;
         this.updateProgress({ downloaded: downloadedBytes });
+      }
+
+      for (const file of plannedFiles) {
+        assertFileSize(file.destPath, file.size, file.path);
+      }
+      const snapshotValidation = validateCt2ModelSnapshot(snapshotDir);
+      if (!snapshotValidation.ok) {
+        throw new Error(
+          `CT2 model snapshot is incomplete: ${snapshotValidation.issues.join(', ')}`,
+        );
       }
 
       saveDownloadState(null);
@@ -496,6 +516,47 @@ export class FasterWhisperModelDownloader {
           return;
         }
 
+        const contentRangeHeader = response.headers['content-range'];
+        const contentRange = Array.isArray(contentRangeHeader)
+          ? contentRangeHeader[0]
+          : contentRangeHeader;
+        let disposition: ReturnType<typeof validateDownloadResponse>;
+        try {
+          disposition = validateDownloadResponse(
+            response.statusCode,
+            contentRange,
+            startByte,
+            fileSize,
+          );
+        } catch (error) {
+          isCompleted = true;
+          clearInactivityTimer();
+          signal?.removeEventListener('abort', onAbort);
+          response.resume();
+          reject(error);
+          return;
+        }
+
+        if (disposition === 'restart') {
+          isCompleted = true;
+          clearInactivityTimer();
+          signal?.removeEventListener('abort', onAbort);
+          response.resume();
+          fs.rmSync(destPath, { force: true });
+          this.downloadFile(
+            url,
+            destPath,
+            0,
+            progressKey,
+            baseDownloaded,
+            totalBytes,
+            fileSize,
+          )
+            .then(resolve)
+            .catch(reject);
+          return;
+        }
+
         const fileStream = fs.createWriteStream(destPath, {
           flags: startByte > 0 ? 'a' : 'w',
         });
@@ -517,11 +578,24 @@ export class FasterWhisperModelDownloader {
           isCompleted = true;
           clearInactivityTimer();
           signal?.removeEventListener('abort', onAbort);
-          if (fileDownloaded < fileSize && response.statusCode === 200) {
+          try {
+            assertFileSize(destPath, fileSize);
             resolve();
-            return;
+          } catch (error) {
+            reject(error);
           }
-          resolve();
+        });
+
+        response.on('aborted', () => {
+          fileStream.destroy();
+          isCompleted = true;
+          clearInactivityTimer();
+          signal?.removeEventListener('abort', onAbort);
+          reject(
+            new Error(
+              `Download ended early: got ${fileDownloaded}, expected ${fileSize}`,
+            ),
+          );
         });
 
         fileStream.on('error', (error) => {

--- a/main/helpers/modelCatalog.ts
+++ b/main/helpers/modelCatalog.ts
@@ -8,6 +8,10 @@ import {
   hfRepoToCacheDirName,
   getCt2HfRepo,
 } from './fasterWhisperModelCatalog';
+import {
+  inspectCt2SnapshotRoot,
+  type Ct2SnapshotInspection,
+} from './modelImport';
 
 /** ggml 路径：语义不变，复用 getPath('modelsPath') */
 export function getGgmlModelsPath(): string {
@@ -61,34 +65,41 @@ export function getCt2ModelCacheDir(modelId: string): string {
   return path.join(getFasterWhisperHubDir(), toCt2CacheDirName(modelId));
 }
 
-/** 解析 UI 模型目录下的 snapshot 绝对路径（仅查 fasterWhisperModelsPath） */
-export function resolveCt2ModelSnapshotDir(modelId: string): string | null {
+/** 检查 UI 模型目录下的 snapshot，并保留残缺模型的诊断信息。 */
+export function inspectCt2ModelSnapshot(
+  modelId: string,
+): Ct2SnapshotInspection {
   const dirName = toCt2CacheDirName(modelId);
   const snapshotRoots = [
     path.join(getFasterWhisperHubDir(), dirName, 'snapshots'),
     path.join(getFasterWhisperModelsPath(), dirName, 'snapshots'),
   ];
 
+  let firstIncomplete: Ct2SnapshotInspection | null = null;
   for (const snapshotRoot of snapshotRoots) {
-    if (!fs.existsSync(snapshotRoot)) continue;
-    for (const rev of fs.readdirSync(snapshotRoot)) {
-      const snapshotDir = path.join(snapshotRoot, rev);
-      if (fs.existsSync(path.join(snapshotDir, 'model.bin'))) {
-        return snapshotDir;
-      }
+    const inspection = inspectCt2SnapshotRoot(snapshotRoot);
+    if (inspection.snapshotDir) return inspection;
+    if (!firstIncomplete && inspection.incompleteSnapshotDir) {
+      firstIncomplete = inspection;
     }
   }
-  return null;
+  return (
+    firstIncomplete || {
+      ok: false,
+      snapshotDir: null,
+      incompleteSnapshotDir: null,
+      issues: [],
+    }
+  );
 }
 
-function snapshotDirHasModelBin(snapshotRoot: string): boolean {
-  if (!fs.existsSync(snapshotRoot)) return false;
-  for (const rev of fs.readdirSync(snapshotRoot)) {
-    if (fs.existsSync(path.join(snapshotRoot, rev, 'model.bin'))) {
-      return true;
-    }
-  }
-  return false;
+/** 仅返回完整、可加载的 CT2 snapshot 绝对路径。 */
+export function resolveCt2ModelSnapshotDir(modelId: string): string | null {
+  return inspectCt2ModelSnapshot(modelId).snapshotDir;
+}
+
+function snapshotDirHasCompleteModel(snapshotRoot: string): boolean {
+  return inspectCt2SnapshotRoot(snapshotRoot).snapshotDir !== null;
 }
 
 function collectInstalledFromHubLikeDir(
@@ -100,7 +111,7 @@ function collectInstalledFromHubLikeDir(
     const mapped = cacheDirNameToModelId(entry);
     if (!mapped) continue;
     const snapshotRoot = path.join(hubDir, entry, 'snapshots');
-    if (snapshotDirHasModelBin(snapshotRoot)) {
+    if (snapshotDirHasCompleteModel(snapshotRoot)) {
       found.add(mapped);
     }
   }

--- a/main/helpers/modelImport.ts
+++ b/main/helpers/modelImport.ts
@@ -62,5 +62,111 @@ export function resolveBundledDenoisePath(extraResourcesRoot: string): string {
 /** CT2(faster-whisper) 模型导入的最小必需文件集（模型权重 + 配置）。 */
 export const CT2_REQUIRED_FILES: string[] = ['model.bin', 'config.json'];
 
+/** CTranslate2 Whisper 转写阶段会直接迭代的配置数组。 */
+export const CT2_REQUIRED_CONFIG_ARRAYS: string[] = [
+  'lang_ids',
+  'suppress_ids',
+  'suppress_ids_begin',
+];
+
 /** 导入的 CT2 模型落地的合成快照 revision 名，供 resolveCt2ModelSnapshotDir 命中。 */
 export const CT2_IMPORT_SNAPSHOT_REV = 'imported';
+
+export interface Ct2SnapshotValidation {
+  ok: boolean;
+  issues: string[];
+}
+
+export interface Ct2SnapshotInspection extends Ct2SnapshotValidation {
+  snapshotDir: string | null;
+  incompleteSnapshotDir: string | null;
+}
+
+/**
+ * 校验 faster-whisper/CT2 快照的最小可加载条件。
+ * 除必需文件存在外，文件必须非空，且 config.json 必须是 JSON 对象，避免把
+ * CTranslate2 的底层 JSON 异常暴露到转写阶段。
+ */
+export function validateCt2ModelSnapshot(
+  snapshotDir: string,
+): Ct2SnapshotValidation {
+  const issues: string[] = [];
+
+  for (const rel of CT2_REQUIRED_FILES) {
+    const filePath = path.join(snapshotDir, rel);
+    try {
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile() || stat.size <= 0) issues.push(`${rel} is empty`);
+    } catch {
+      issues.push(`${rel} is missing`);
+    }
+  }
+
+  const configPath = path.join(snapshotDir, 'config.json');
+  if (!issues.some((issue) => issue.startsWith('config.json'))) {
+    try {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      if (!config || typeof config !== 'object' || Array.isArray(config)) {
+        issues.push('config.json is invalid');
+      } else {
+        for (const key of CT2_REQUIRED_CONFIG_ARRAYS) {
+          if (!Array.isArray((config as Record<string, unknown>)[key])) {
+            issues.push(`config.json.${key} is missing or invalid`);
+          }
+        }
+      }
+    } catch {
+      issues.push('config.json is invalid');
+    }
+  }
+
+  return { ok: issues.length === 0, issues };
+}
+
+/** 在一个 snapshots 目录中优先返回完整快照，同时保留首个残缺快照的诊断。 */
+export function inspectCt2SnapshotRoot(
+  snapshotRoot: string,
+): Ct2SnapshotInspection {
+  if (!fs.existsSync(snapshotRoot)) {
+    return {
+      ok: false,
+      snapshotDir: null,
+      incompleteSnapshotDir: null,
+      issues: [],
+    };
+  }
+
+  let firstIncomplete: Ct2SnapshotInspection | null = null;
+  const revisions = fs
+    .readdirSync(snapshotRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const revision of revisions) {
+    const snapshotDir = path.join(snapshotRoot, revision.name);
+    const validation = validateCt2ModelSnapshot(snapshotDir);
+    if (validation.ok) {
+      return {
+        ...validation,
+        snapshotDir,
+        incompleteSnapshotDir: null,
+      };
+    }
+    if (!firstIncomplete) {
+      firstIncomplete = {
+        ...validation,
+        snapshotDir: null,
+        incompleteSnapshotDir: snapshotDir,
+      };
+    }
+  }
+
+  return (
+    firstIncomplete || {
+      ok: false,
+      snapshotDir: null,
+      incompleteSnapshotDir: null,
+      issues: [],
+    }
+  );
+}

--- a/main/helpers/systemInfoManager.ts
+++ b/main/helpers/systemInfoManager.ts
@@ -8,6 +8,7 @@ import {
 } from './modelCatalog';
 import {
   validateModelLayout,
+  validateCt2ModelSnapshot,
   CT2_REQUIRED_FILES,
   CT2_IMPORT_SNAPSHOT_REV,
 } from './modelImport';
@@ -99,17 +100,24 @@ let downloadingModels = new Set<string>();
 
 /** 可文件夹导入的引擎类型（builtin 走单文件导入，不在此列）。 */
 type FolderImportEngine =
-  | 'funasr'
-  | 'qwen'
-  | 'fireRedAsr'
-  | 'fasterWhisper'
-  | 'tts';
+  'funasr' | 'qwen' | 'fireRedAsr' | 'fasterWhisper' | 'tts';
 
 interface ImportPlan {
   /** 目标模型必需文件（相对源/目的目录），用于导入前后布局校验。 */
   requiredFiles: string[];
   /** 拷贝目的地（绝对路径）。 */
   destDir: string;
+  /** 引擎专用的额外内容校验；默认仅检查 requiredFiles。 */
+  validate?: (dir: string) => { ok: boolean; missing: string[] };
+}
+
+function validateImportLayout(
+  plan: ImportPlan,
+  dir: string,
+): { ok: boolean; missing: string[] } {
+  return plan.validate
+    ? plan.validate(dir)
+    : validateModelLayout(dir, plan.requiredFiles);
 }
 
 /**
@@ -156,6 +164,10 @@ function resolveImportPlan(
         'snapshots',
         CT2_IMPORT_SNAPSHOT_REV,
       ),
+      validate: (dir) => {
+        const result = validateCt2ModelSnapshot(dir);
+        return { ok: result.ok, missing: result.issues };
+      },
     };
   }
   if (engine === 'tts') {
@@ -613,7 +625,7 @@ export function setupSystemInfoManager(mainWindow: BrowserWindow) {
       const srcDir = picked.filePaths[0];
 
       // 导入前校验布局：缺关键文件直接拒绝，不写盘
-      const pre = validateModelLayout(srcDir, plan.requiredFiles);
+      const pre = validateImportLayout(plan, srcDir);
       if (!pre.ok) {
         return {
           success: false,
@@ -638,7 +650,7 @@ export function setupSystemInfoManager(mainWindow: BrowserWindow) {
       }
 
       // 导入后复校验：拷贝后目的地必须齐备
-      const post = validateModelLayout(plan.destDir, plan.requiredFiles);
+      const post = validateImportLayout(plan, plan.destDir);
       if (!post.ok) {
         return {
           success: false,

--- a/main/helpers/systemInfoManager.ts
+++ b/main/helpers/systemInfoManager.ts
@@ -100,7 +100,11 @@ let downloadingModels = new Set<string>();
 
 /** 可文件夹导入的引擎类型（builtin 走单文件导入，不在此列）。 */
 type FolderImportEngine =
-  'funasr' | 'qwen' | 'fireRedAsr' | 'fasterWhisper' | 'tts';
+  | 'funasr'
+  | 'qwen'
+  | 'fireRedAsr'
+  | 'fasterWhisper'
+  | 'tts';
 
 interface ImportPlan {
   /** 目标模型必需文件（相对源/目的目录），用于导入前后布局校验。 */

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -57,11 +57,20 @@ import {
 import { QWEN_MODELS } from '../main/helpers/qwenModelCatalog';
 import { FIRERED_MODELS } from '../main/helpers/fireRedModelCatalog';
 import {
+  CT2_REQUIRED_FILES,
+  CT2_REQUIRED_CONFIG_ARRAYS,
+  inspectCt2SnapshotRoot,
   validateModelLayout,
+  validateCt2ModelSnapshot,
   resolveOverridePath,
   resolveBundledVadPath,
   SHERPA_VAD_SUBPATH,
 } from '../main/helpers/modelImport';
+import {
+  assertFileSize,
+  prepareDownloadTarget,
+  validateDownloadResponse,
+} from '../main/helpers/download/resumeIntegrity';
 import {
   buildVadConfig,
   buildRecognizerConfig,
@@ -1194,6 +1203,136 @@ eq(
   '/default/models',
   'path: whitespace -> fallback',
 );
+
+// --- CT2 模型完整性：残缺快照不算已安装，完整快照优先 ---
+{
+  const tmp = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'ct2-integrity-'));
+  const snapshots = nodePath.join(tmp, 'snapshots');
+  const incomplete = nodePath.join(snapshots, 'a-incomplete');
+  const complete = nodePath.join(snapshots, 'b-complete');
+  fs.mkdirSync(incomplete, { recursive: true });
+  fs.mkdirSync(complete, { recursive: true });
+  fs.writeFileSync(nodePath.join(incomplete, 'model.bin'), 'model');
+  fs.writeFileSync(nodePath.join(complete, 'model.bin'), 'model');
+  fs.writeFileSync(
+    nodePath.join(complete, 'config.json'),
+    JSON.stringify({
+      lang_ids: [],
+      suppress_ids: [],
+      suppress_ids_begin: [],
+    }),
+  );
+
+  eq(
+    CT2_REQUIRED_FILES,
+    ['model.bin', 'config.json'],
+    'ct2 integrity: minimum required files stay centralized',
+  );
+  eq(
+    CT2_REQUIRED_CONFIG_ARRAYS,
+    ['lang_ids', 'suppress_ids', 'suppress_ids_begin'],
+    'ct2 integrity: native config arrays stay centralized',
+  );
+  eq(
+    validateCt2ModelSnapshot(incomplete).issues,
+    ['config.json is missing'],
+    'ct2 integrity: missing config is diagnosed',
+  );
+  eq(
+    inspectCt2SnapshotRoot(snapshots).snapshotDir,
+    complete,
+    'ct2 integrity: complete snapshot wins over earlier incomplete snapshot',
+  );
+
+  fs.writeFileSync(nodePath.join(complete, 'config.json'), 'null');
+  eq(
+    validateCt2ModelSnapshot(complete).issues,
+    ['config.json is invalid'],
+    'ct2 integrity: null config is rejected before native runtime',
+  );
+  fs.writeFileSync(nodePath.join(complete, 'config.json'), '{}');
+  eq(
+    validateCt2ModelSnapshot(complete).issues,
+    [
+      'config.json.lang_ids is missing or invalid',
+      'config.json.suppress_ids is missing or invalid',
+      'config.json.suppress_ids_begin is missing or invalid',
+    ],
+    'ct2 integrity: missing native config arrays are diagnosed',
+  );
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+// --- CT2 下载恢复：最终文件按大小校验，短文件续传，错误 Range 拒绝 ---
+{
+  const tmp = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'ct2-resume-'));
+  const dest = nodePath.join(tmp, 'model.bin');
+  const partial = `${dest}.download`;
+
+  fs.writeFileSync(dest, 'abc');
+  eq(
+    prepareDownloadTarget(dest, partial, 5),
+    { complete: false, startByte: 3 },
+    'ct2 resume: short final file becomes resumable temp file',
+  );
+  eq(
+    [fs.existsSync(dest), fs.statSync(partial).size],
+    [false, 3],
+    'ct2 resume: incomplete final file is never skipped',
+  );
+
+  fs.writeFileSync(partial, 'abcdef');
+  eq(
+    prepareDownloadTarget(dest, partial, 5),
+    { complete: false, startByte: 0 },
+    'ct2 resume: oversized temp file is discarded',
+  );
+
+  fs.writeFileSync(dest, 'abcde');
+  eq(
+    prepareDownloadTarget(dest, partial, 5),
+    { complete: true, startByte: 0 },
+    'ct2 resume: exact-size final file may be skipped',
+  );
+  assertFileSize(dest, 5);
+
+  fs.writeFileSync(dest, 'abc');
+  let shortFileError = '';
+  try {
+    assertFileSize(dest, 5, 'model.bin');
+  } catch (error) {
+    shortFileError = error instanceof Error ? error.message : String(error);
+  }
+  eq(
+    shortFileError.includes('size mismatch'),
+    true,
+    'ct2 resume: early EOF cannot pass final size check',
+  );
+
+  eq(
+    validateDownloadResponse(200, undefined, 3, 5),
+    'restart',
+    'ct2 resume: ignored Range restarts from zero',
+  );
+  eq(
+    validateDownloadResponse(206, 'bytes 3-4/5', 3, 5),
+    'accept',
+    'ct2 resume: matching Content-Range is accepted',
+  );
+  let rangeError = '';
+  try {
+    validateDownloadResponse(206, 'bytes 2-4/5', 3, 5);
+  } catch (error) {
+    rangeError = error instanceof Error ? error.message : String(error);
+  }
+  eq(
+    rangeError.includes('Content-Range mismatch'),
+    true,
+    'ct2 resume: mismatched Content-Range is rejected',
+  );
+
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
 
 // --- modelImport: 内置共享 VAD 路径（随包内置，与引擎模型根解耦） ---
 eq(


### PR DESCRIPTION
close #382

## 修改

- 残缺或无效的 CT2 模型不再显示为已安装，转写前给出可操作提示。
- 下载与续传按远端大小校验；错误 Range 重新下载，提前 EOF 明确失败。
- 下载完成和手动导入统一复校验模型文件与关键配置。

## 验证

- `npm run test:engines`：669 项通过
- `npm run check:i18n`：通过
- Prettier 与定向 TypeScript 检查：通过
- `npm run build`：渲染器编译、类型检查及 36 个静态页面生成完成；Next.js worker 收尾退出 1，仅输出仓库既有警告

## 未包含

- 未改动 FunASR 等其他引擎；原报告者仍需确认实际引擎并复测。
