### PR TITLE
增加翻译重试提示词开关

### DIFF
--- a/main/translate/services/ai.ts
+++ b/main/translate/services/ai.ts
@@ -37,6 +37,7 @@ import {
   selectGlossaryPromptEntries,
 } from '../../glossary/core';
 import { logGlossaryMatches } from '../../helpers/glossaryManager';
+import { buildAITranslationPromptForAttempt } from '../utils/aiRetryPrompt';
 
 function getLanguageName(code: string): string {
   // 中文目标须向 AI 明确简/繁，避免「中文」歧义导致译文简繁混杂（issue #332）。
@@ -197,20 +198,18 @@ export async function handleAIBatchTranslation(
           batchJsonContent[item.id] = item.content.join('\n');
         });
         const fullContent = `${JSON.stringify(batchJsonContent, null, 2)}`;
-        let translationContent = renderTemplate(
-          provider.prompt || defaultUserPrompt,
-          {
+        const translationContent = buildAITranslationPromptForAttempt(
+          renderTemplate(provider.prompt || defaultUserPrompt, {
             sourceLanguage: sourceLanguageName,
             targetLanguage: targetLanguageName,
             content: fullContent,
+          }),
+          {
+            isRetry: retryCount > 0 || alignmentRetryUsed,
+            echoEnabled,
+            appendRetryPrompt: provider.appendRetryPrompt,
           },
         );
-
-        if (retryCount > 0 || alignmentRetryUsed) {
-          translationContent += echoEnabled
-            ? '\n\n上一次响应存在错位或无法解析。请只返回一个 JSON 对象：键必须与输入字幕 ID 完全一致，每个键的值是 {"src": ..., "tr": ...}。注意：src 必须逐字复制输入中该 ID 对应的原文（保持原语言，绝对不能填译文），tr 才是译文；禁止合并或拆分条目，不要返回 markdown、解释或思考过程。'
-            : '\n\n上一次响应无法解析。请只返回一个 JSON 对象，键必须是输入字幕 ID，值必须是翻译结果；不要返回 markdown、解释、注释或思考过程。';
-        }
 
         const systemPrompt = renderGlossarySystemPrompt(
           provider.systemPrompt || defaultSystemPrompt,

--- a/main/translate/utils/aiRetryPrompt.ts
+++ b/main/translate/utils/aiRetryPrompt.ts
@@ -1,0 +1,25 @@
+export const AI_RETRY_FORMAT_INSTRUCTION =
+  '上一次响应无法解析。请只返回一个 JSON 对象，键必须是输入字幕 ID，值必须是翻译结果；不要返回 markdown、解释、注释或思考过程。';
+
+export const AI_ECHO_RETRY_FORMAT_INSTRUCTION =
+  '上一次响应存在错位或无法解析。请只返回一个 JSON 对象：键必须与输入字幕 ID 完全一致，每个键的值是 {"src": ..., "tr": ...}。注意：src 必须逐字复制输入中该 ID 对应的原文（保持原语言，绝对不能填译文），tr 才是译文；禁止合并或拆分条目，不要返回 markdown、解释或思考过程。';
+
+interface AITranslationPromptAttemptOptions {
+  isRetry: boolean;
+  echoEnabled: boolean;
+  appendRetryPrompt?: boolean;
+}
+
+export function buildAITranslationPromptForAttempt(
+  basePrompt: string,
+  options: AITranslationPromptAttemptOptions,
+): string {
+  if (!options.isRetry || options.appendRetryPrompt === false) {
+    return basePrompt;
+  }
+
+  const instruction = options.echoEnabled
+    ? AI_ECHO_RETRY_FORMAT_INSTRUCTION
+    : AI_RETRY_FORMAT_INSTRUCTION;
+  return `${basePrompt}\n\n${instruction}`;
+}

--- a/renderer/lib/providerPanelUtils.ts
+++ b/renderer/lib/providerPanelUtils.ts
@@ -7,6 +7,7 @@ export const LAST_PROVIDER_STORAGE_KEY = 'resourcesProvidersSelectedId';
 export const PROVIDER_ADVANCED_FIELD_KEYS = new Set([
   'systemPrompt',
   'prompt',
+  'appendRetryPrompt',
   'structuredOutput',
   'windowMaxRequests',
 ]);

--- a/renderer/public/locales/en/translateControl.json
+++ b/renderer/public/locales/en/translateControl.json
@@ -98,6 +98,8 @@
   "echoAnchoring": "Echo Alignment Check",
   "echoAnchoringTips": "When enabled, the model returns both the source echo and the translation for every subtitle entry. The app uses the echo to detect and repair misalignment caused by merged neighbouring subtitles, keeping translations aligned with the timeline. Roughly doubles output token usage; when disabled, only count and empty-value checks apply.",
   "echoPromptOutdatedHint": "Your custom prompt does not include the src/tr echo protocol. Translation still works, but misalignment detection is unavailable. Consider updating it based on the default prompt, or restoring the default.",
+  "appendRetryPrompt": "Append Format Prompt on Retry",
+  "appendRetryPromptTips": "When enabled, retries append JSON format or echo-alignment instructions to the user prompt. When disabled, retries reuse the original user prompt unchanged.",
   "doubaoApiKeyTips": "Doubao Translation API Key, can be obtained from <a href='https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey' style='color: blue'>Volcano Ark Console</a>",
   "doubaoModelNameTips": "Doubao translation model name, default is doubao-seed-translation-250915, usually no need to modify",
   "batchSizeDoubaoTips": "Doubao translation batch size, due to API limits, recommended to set to 1",

--- a/renderer/public/locales/zh/translateControl.json
+++ b/renderer/public/locales/zh/translateControl.json
@@ -100,6 +100,8 @@
   "echoAnchoring": "回显对齐校验",
   "echoAnchoringTips": "开启后模型会对每条字幕同时返回原文回显与译文，系统据此检测并修复「相邻字幕被合并翻译导致的错位」，确保译文与时间轴逐条对齐。会增加约一倍的输出 token 消耗；关闭后仅校验条数与空值。",
   "echoPromptOutdatedHint": "当前自定义提示词未包含 src/tr 回显协议，翻译仍可进行，但无法享受错位检测保护。建议参考默认提示词更新，或恢复默认值。",
+  "appendRetryPrompt": "重试时追加格式提示词",
+  "appendRetryPromptTips": "开启后，重试请求会在用户提示词末尾追加 JSON 格式或回显对齐要求；关闭后，重试将原样沿用用户提示词。",
   "doubaoApiKeyTips": "豆包翻译 API Key，可在 <a href='https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey' style='color: blue'>火山方舟控制台</a> 获取",
   "doubaoModelNameTips": "豆包翻译模型名称，默认为 doubao-seed-translation-250915，一般无需修改",
   "batchSizeDoubaoTips": "豆包翻译批量大小，由于 API 限制，建议设置为 1",

--- a/scripts/test-ai-response-parser.ts
+++ b/scripts/test-ai-response-parser.ts
@@ -9,6 +9,11 @@ import {
   normalizeForComparison,
   textSimilarity,
 } from '../main/translate/utils/similarity';
+import {
+  AI_ECHO_RETRY_FORMAT_INSTRUCTION,
+  AI_RETRY_FORMAT_INSTRUCTION,
+  buildAITranslationPromptForAttempt,
+} from '../main/translate/utils/aiRetryPrompt';
 
 let passed = 0;
 let failed = 0;
@@ -223,6 +228,47 @@ eq(
   ) < 0.75,
   true,
   'similarity: merged echo falls below threshold',
+);
+
+const basePrompt = 'Translate this JSON exactly.';
+
+eq(
+  buildAITranslationPromptForAttempt(basePrompt, {
+    isRetry: false,
+    echoEnabled: true,
+    appendRetryPrompt: true,
+  }),
+  basePrompt,
+  'retry prompt: first attempt stays unchanged',
+);
+
+eq(
+  buildAITranslationPromptForAttempt(basePrompt, {
+    isRetry: true,
+    echoEnabled: false,
+  }),
+  `${basePrompt}\n\n${AI_RETRY_FORMAT_INSTRUCTION}`,
+  'retry prompt: missing setting preserves enabled default',
+);
+
+eq(
+  buildAITranslationPromptForAttempt(basePrompt, {
+    isRetry: true,
+    echoEnabled: true,
+    appendRetryPrompt: true,
+  }),
+  `${basePrompt}\n\n${AI_ECHO_RETRY_FORMAT_INSTRUCTION}`,
+  'retry prompt: enabled appends the echo-alignment instruction',
+);
+
+eq(
+  buildAITranslationPromptForAttempt(basePrompt, {
+    isRetry: true,
+    echoEnabled: true,
+    appendRetryPrompt: false,
+  }),
+  basePrompt,
+  'retry prompt: disabled reuses the original prompt for aligned retries',
 );
 
 if (failed > 0) {

--- a/types/provider.ts
+++ b/types/provider.ts
@@ -277,6 +277,15 @@ const FIELD_USER_PROMPT: ProviderField = {
   tips: 'userPromptTips',
 };
 
+const FIELD_APPEND_RETRY_PROMPT: ProviderField = {
+  key: 'appendRetryPrompt',
+  label: 'appendRetryPrompt',
+  type: 'switch',
+  required: false,
+  defaultValue: true,
+  tips: 'appendRetryPromptTips',
+};
+
 const batchSizeField = (
   defaultValue: number = 1,
   tips: string = 'batchSizeTip',
@@ -327,6 +336,7 @@ const aiCommonFields = (overrides?: {
 }): ProviderField[] => [
   FIELD_SYSTEM_PROMPT,
   FIELD_USER_PROMPT,
+  FIELD_APPEND_RETRY_PROMPT,
   structuredOutputField(overrides?.structuredOutput),
   FIELD_ECHO_ANCHORING,
   batchSizeField(overrides?.batchSize, overrides?.batchSizeTips),


### PR DESCRIPTION
close #384

## 改动
- 为所有 AI 翻译服务商新增“重试时追加格式提示词”开关，默认开启，兼容旧配置。
- 关闭后重试沿用原用户提示词；开启后保留现有 JSON 格式提示。
- 提取重试提示词构造逻辑，覆盖首次、旧配置、开启和关闭四种情况。

## 验证
- `npm run check:i18n`
- `npm run test:translate-parser`
- `npm run test:engines`
- `npm run test:glossary`
- `npm run test:structured-output`
- `npm run test:translation-cancel`
- `npm run test:dubbing`

## 说明
- 本地构建已通过 renderer 的 lint、类型检查和静态页面生成；main 打包受现有 Nextron/webpack 依赖冲突阻断，交由 GitHub Node 20 干净环境复核。
