### PR TITLE
Improve FunASR download failure guidance

### DIFF
--- a/renderer/components/resources/FunasrModelSection.tsx
+++ b/renderer/components/resources/FunasrModelSection.tsx
@@ -18,7 +18,10 @@ import SherpaModelRow from '@/components/resources/SherpaModelRow';
 import DownloadSourcePopover, {
   useDownloadSource,
 } from '@/components/resources/engines/DownloadSourcePopover';
-import { formatFunasrDownloadFailureToast } from '@/lib/funasrDownloadError';
+import {
+  formatFunasrDownloadFailureToast,
+  isFunasrDownloadCancelled,
+} from '@/lib/funasrDownloadError';
 import { importModelFromFolder } from 'lib/importModel';
 import { resolveModelDownloadUrl } from 'lib/resolveModelDownloadUrl';
 
@@ -91,6 +94,9 @@ const FunasrModelSection: React.FC<{
         await load();
         onUpdate?.();
       } else {
+        if (isFunasrDownloadCancelled(r?.error)) {
+          return;
+        }
         if (r?.error === 'anotherDownloadInProgress') {
           toast.error(t('engines.funasr.anotherDownload'));
         } else {
@@ -106,6 +112,7 @@ const FunasrModelSection: React.FC<{
         }
       }
     } catch (e) {
+      if (isFunasrDownloadCancelled(e)) return;
       const failure = formatFunasrDownloadFailureToast(t, id, String(e));
       toast.error(failure.title, {
         description: failure.description,

--- a/renderer/components/resources/FunasrModelSection.tsx
+++ b/renderer/components/resources/FunasrModelSection.tsx
@@ -18,6 +18,7 @@ import SherpaModelRow from '@/components/resources/SherpaModelRow';
 import DownloadSourcePopover, {
   useDownloadSource,
 } from '@/components/resources/engines/DownloadSourcePopover';
+import { formatFunasrDownloadFailureToast } from '@/lib/funasrDownloadError';
 import { importModelFromFolder } from 'lib/importModel';
 import { resolveModelDownloadUrl } from 'lib/resolveModelDownloadUrl';
 
@@ -90,14 +91,26 @@ const FunasrModelSection: React.FC<{
         await load();
         onUpdate?.();
       } else {
-        toast.error(
-          r?.error === 'anotherDownloadInProgress'
-            ? t('engines.funasr.anotherDownload')
-            : r?.error || 'Failed to download model',
-        );
+        if (r?.error === 'anotherDownloadInProgress') {
+          toast.error(t('engines.funasr.anotherDownload'));
+        } else {
+          const failure = formatFunasrDownloadFailureToast(
+            t,
+            id,
+            r?.error || '',
+          );
+          toast.error(failure.title, {
+            description: failure.description,
+            duration: 8000,
+          });
+        }
       }
     } catch (e) {
-      toast.error(String(e));
+      const failure = formatFunasrDownloadFailureToast(t, id, String(e));
+      toast.error(failure.title, {
+        description: failure.description,
+        duration: 8000,
+      });
     } finally {
       setDownloading(null);
       setProgress((prev) => ({ ...prev, [`funasr:${id}`]: 0 }));

--- a/renderer/lib/funasrDownloadError.ts
+++ b/renderer/lib/funasrDownloadError.ts
@@ -1,0 +1,34 @@
+export type FunasrModelId = 'sensevoice-small' | 'paraformer-zh' | 'silero-vad';
+
+const REQUIRED_FILES: Record<FunasrModelId, string[]> = {
+  'sensevoice-small': ['model.int8.onnx', 'tokens.txt'],
+  'paraformer-zh': ['model.int8.onnx', 'tokens.txt'],
+  'silero-vad': ['silero_vad.onnx'],
+};
+
+type Translate = (
+  key: string,
+  values?: Record<string, string>,
+) => string;
+
+export interface FunasrDownloadFailureToast {
+  title: string;
+  description: string;
+}
+
+export function formatFunasrDownloadFailureToast(
+  t: Translate,
+  modelId: FunasrModelId,
+  rawError: string,
+): FunasrDownloadFailureToast {
+  const files = REQUIRED_FILES[modelId].join(', ');
+  const details = rawError.trim();
+  const fallback = t('engines.funasr.downloadFailedManualHint', {
+    files,
+  });
+
+  return {
+    title: t('engines.funasr.downloadFailed'),
+    description: details ? `${details}\n${fallback}` : fallback,
+  };
+}

--- a/renderer/lib/funasrDownloadError.ts
+++ b/renderer/lib/funasrDownloadError.ts
@@ -6,10 +6,7 @@ const REQUIRED_FILES: Record<FunasrModelId, string[]> = {
   'silero-vad': ['silero_vad.onnx'],
 };
 
-type Translate = (
-  key: string,
-  values?: Record<string, string>,
-) => string;
+type Translate = (key: string, values?: Record<string, string>) => string;
 
 export interface FunasrDownloadFailureToast {
   title: string;
@@ -25,7 +22,7 @@ export function isFunasrDownloadCancelled(error: unknown): boolean {
       : error instanceof Error
         ? `${error.name} ${error.message}`
         : String(error);
-  return /\b(cancelled|canceled|abort(?:ed)?)\b/i.test(message);
+  return /\bDownload cancell?ed\b/i.test(message);
 }
 
 export function formatFunasrDownloadFailureToast(

--- a/renderer/lib/funasrDownloadError.ts
+++ b/renderer/lib/funasrDownloadError.ts
@@ -16,6 +16,18 @@ export interface FunasrDownloadFailureToast {
   description: string;
 }
 
+export function isFunasrDownloadCancelled(error: unknown): boolean {
+  if (!error) return false;
+  if (error instanceof DOMException && error.name === 'AbortError') return true;
+  const message =
+    typeof error === 'string'
+      ? error
+      : error instanceof Error
+        ? `${error.name} ${error.message}`
+        : String(error);
+  return /\b(cancelled|canceled|abort(?:ed)?)\b/i.test(message);
+}
+
 export function formatFunasrDownloadFailureToast(
   t: Translate,
   modelId: FunasrModelId,

--- a/renderer/public/locales/en/resources.json
+++ b/renderer/public/locales/en/resources.json
@@ -125,6 +125,8 @@
       "checkFailed": "Failed to check for updates. Please try again later.",
       "protocolUnsupported": "This engine version requires a newer SmartSub. Please update SmartSub before installing or upgrading the engine.",
       "anotherDownload": "Another download is in progress. Please wait for it to finish.",
+      "downloadFailed": "FunASR model download failed",
+      "downloadFailedManualHint": "If the selected source is blocked or times out, copy the model page link from the download source popover, download the folder manually, then use Import from folder. The folder must contain: {{files}}.",
       "advanced": "Advanced settings",
       "itn": "Inverse text normalization (ITN)",
       "itnHint": "Converts spoken numbers, dates, etc. into standard written form and restores punctuation",

--- a/renderer/public/locales/zh/resources.json
+++ b/renderer/public/locales/zh/resources.json
@@ -125,6 +125,8 @@
       "checkFailed": "检查更新失败，请稍后重试。",
       "protocolUnsupported": "该引擎版本需要更新版本的 SmartSub，请先升级 SmartSub 后再安装或升级引擎。",
       "anotherDownload": "已有下载任务进行中，请等待完成后再试。",
+      "downloadFailed": "FunASR 模型下载失败",
+      "downloadFailedManualHint": "如果当前下载源被拦截或超时，可在下载源弹窗复制模型页链接，手动下载模型文件夹后使用「从文件夹导入」。该文件夹必须包含：{{files}}。",
       "advanced": "高级设置",
       "itn": "逆文本规整（ITN）",
       "itnHint": "将口语化的数字、日期等转换为标准书写形式，并自动补全标点",

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -82,6 +82,7 @@ import {
   getInstalledModelsForEngine,
   hasModelsForEngine,
 } from '../renderer/lib/engineModels';
+import { formatFunasrDownloadFailureToast } from '../renderer/lib/funasrDownloadError';
 import {
   tokensToTriples,
   wordsToTriples,
@@ -1223,6 +1224,40 @@ eq(
   ['encoder.int8.onnx', 'decoder.int8.onnx', 'tokens.txt'],
   'import: fireRed requiredFiles',
 );
+
+// --- funasr download failure: surface manual fallback next step ---
+{
+  const translations: Record<string, string> = {
+    'engines.funasr.downloadFailed': 'FunASR model download failed',
+    'engines.funasr.downloadFailedManualHint':
+      'Manual import requires: {{files}}.',
+  };
+  const t = (key: string, values?: Record<string, string>) =>
+    (translations[key] || key).replace(
+      /\{\{(\w+)\}\}/g,
+      (_match, name: string) => values?.[name] ?? '',
+    );
+  const toast = formatFunasrDownloadFailureToast(
+    t,
+    'sensevoice-small',
+    'HTTP Error: 403',
+  );
+  eq(
+    toast.title,
+    'FunASR model download failed',
+    'funasr download error: localized title',
+  );
+  eq(
+    toast.description.includes('HTTP Error: 403'),
+    true,
+    'funasr download error: keeps raw failure detail',
+  );
+  eq(
+    toast.description.includes('model.int8.onnx, tokens.txt'),
+    true,
+    'funasr download error: names required manual import files',
+  );
+}
 
 // --- subtitleSegmentation: tokensToTriples（原生逐 token 毫秒 → 字幕三元组） ---
 const T = (a: string, b: string, c: string): TokenTriple => [a, b, c];

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -82,7 +82,10 @@ import {
   getInstalledModelsForEngine,
   hasModelsForEngine,
 } from '../renderer/lib/engineModels';
-import { formatFunasrDownloadFailureToast } from '../renderer/lib/funasrDownloadError';
+import {
+  formatFunasrDownloadFailureToast,
+  isFunasrDownloadCancelled,
+} from '../renderer/lib/funasrDownloadError';
 import {
   tokensToTriples,
   wordsToTriples,
@@ -1256,6 +1259,26 @@ eq(
     toast.description.includes('model.int8.onnx, tokens.txt'),
     true,
     'funasr download error: names required manual import files',
+  );
+  eq(
+    isFunasrDownloadCancelled('Download cancelled'),
+    true,
+    'funasr download error: suppresses active user cancellation',
+  );
+  eq(
+    isFunasrDownloadCancelled('Download canceled'),
+    true,
+    'funasr download error: suppresses alternate canceled spelling',
+  );
+  eq(
+    isFunasrDownloadCancelled(new DOMException('The operation was aborted.', 'AbortError')),
+    true,
+    'funasr download error: suppresses abort errors',
+  );
+  eq(
+    isFunasrDownloadCancelled('HTTP Error: 403'),
+    false,
+    'funasr download error: keeps real download failures visible',
   );
 }
 

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -1271,7 +1271,9 @@ eq(
     'funasr download error: suppresses alternate canceled spelling',
   );
   eq(
-    isFunasrDownloadCancelled(new DOMException('The operation was aborted.', 'AbortError')),
+    isFunasrDownloadCancelled(
+      new DOMException('The operation was aborted.', 'AbortError'),
+    ),
     true,
     'funasr download error: suppresses abort errors',
   );
@@ -1279,6 +1281,11 @@ eq(
     isFunasrDownloadCancelled('HTTP Error: 403'),
     false,
     'funasr download error: keeps real download failures visible',
+  );
+  eq(
+    isFunasrDownloadCancelled('Error: aborted'),
+    false,
+    'funasr download error: keeps aborted network failures visible',
   );
 }
 


### PR DESCRIPTION
## Summary
- show a localized FunASR model download failure toast instead of only raw HTTP/errors
- include the manual fallback path: copy the model page link, download the model folder, then use Import from folder
- name the required files (`model.int8.onnx`, `tokens.txt`) so users can self-check SenseVoice/Paraformer folders before importing

## Root cause
When HF/hf-mirror downloads are blocked, timed out, or return a low-level error, the UI already has the right manual import workflow but the failure toast does not connect the error to that workflow. Users can interpret the model path as deleted even when the model repository still exists.

## Validation
- `corepack yarn test:engines` -> `engine unit tests: 658 passed, 0 failed`
- `corepack yarn check:i18n` -> zh/en key parity OK
- `git diff --check`

Note: this checkout has both `package-lock.json` and `yarn.lock`; `npm ci` is blocked because the npm lock is out of sync with `package.json`, so I used the existing Yarn lockfile for validation.
