### PR TITLE
fix(builtin): chunk ultra-long audio to avoid PartitionAlloc 2GiB crash

### DIFF
--- a/main/helpers/audioProcessor.ts
+++ b/main/helpers/audioProcessor.ts
@@ -541,7 +541,7 @@ export async function splitWavAtBoundaries(
 /**
  * 内置引擎超长音频分片准备（crash fix：≥2GiB 单笔分配被 Electron PartitionAlloc 拒绝，
  * 约 9.3h 的 16kHz 音频在 addon 内一次性 resize 必崩）：
- *  - 时长 ≤ 激活阈值（1.5h）→ null，走原单次转写路径（常规视频零变化）；
+ *  - 时长 ≤ 激活阈值（4h）→ null，走原单次转写路径（常见内容零变化）；
  *  - 超阈值 → 按 ~1h 均衡片数定目标切点，每个切点在 ±45s 窗口内吸附到「最长静音 run 中点」
  *    （避免把一句完整的话切成两段），ffmpeg 切片后返回带偏移的切片列表。
  * WAV 头不可解析 → null（保持旧行为，交由 addon 自行处理）。

--- a/main/helpers/audioProcessor.ts
+++ b/main/helpers/audioProcessor.ts
@@ -14,6 +14,14 @@ import {
   EmbeddedSubtitleStream,
 } from './embeddedSubtitleParser';
 import { stderrTail, toFriendlyFfmpegError } from './ffmpegErrorUtils';
+import { readWavInfo, type WavInfo } from './dubbing/audioPipeline';
+import { windowFrameDb } from './wavWindowEnergy';
+import {
+  planEvenChunkTargets,
+  pickSilenceCut,
+  boundariesFromCuts,
+  CUT_SEARCH_WINDOW_SECONDS,
+} from './builtinAudioChunking';
 
 // 设置ffmpeg路径
 const ffmpegPath = ffmpegStatic.replace('app.asar', 'app.asar.unpacked');
@@ -470,12 +478,27 @@ export async function splitBySilence(
     ];
   }
 
+  return cutWavByBoundaries(audioPath, boundaries, 'cloud-asr-chunk', {
+    signal: opts?.signal,
+  });
+}
+
+/**
+ * 按边界列表用 ffmpeg 切出 16kHz 单声道 PCM WAV 切片（splitBySilence 与内置引擎
+ * 超长音频分片共用的执行器）。失败/取消时清理已产出的切片，避免残留。
+ */
+async function cutWavByBoundaries(
+  audioPath: string,
+  boundaries: Array<{ start: number; end: number }>,
+  filePrefix: string,
+  opts?: { signal?: AbortSignal },
+): Promise<CloudAudioChunk[]> {
   const tempDir = ensureTempDir();
   const chunks: CloudAudioChunk[] = [];
   try {
     for (const b of boundaries) {
       if (opts?.signal?.aborted) throw new TaskCancelledError();
-      const outPath = path.join(tempDir, `cloud-asr-chunk-${uuidv4()}.wav`);
+      const outPath = path.join(tempDir, `${filePrefix}-${uuidv4()}.wav`);
       const command = ffmpeg(audioPath)
         .setStartTime(b.start)
         .setDuration(Math.max(0.1, b.end - b.start))
@@ -491,7 +514,6 @@ export async function splitBySilence(
       });
     }
   } catch (error) {
-    // 失败/取消：清理已产出的切片，避免残留。
     for (const c of chunks) {
       try {
         if (fs.existsSync(c.path)) fs.unlinkSync(c.path);
@@ -502,6 +524,76 @@ export async function splitBySilence(
     throw error;
   }
   return chunks;
+}
+
+/**
+ * 内置引擎超长音频分片：按调用方预先算好的「静音对齐」边界切片（16kHz 单声道 PCM WAV），
+ * 返回带起始偏移的切片列表供转写结果回拼。清理责任在调用方（cleanupCloudChunks）。
+ */
+export async function splitWavAtBoundaries(
+  audioPath: string,
+  boundaries: Array<{ start: number; end: number }>,
+  opts?: { signal?: AbortSignal },
+): Promise<CloudAudioChunk[]> {
+  return cutWavByBoundaries(audioPath, boundaries, 'builtin-chunk', opts);
+}
+
+/**
+ * 内置引擎超长音频分片准备（crash fix：≥2GiB 单笔分配被 Electron PartitionAlloc 拒绝，
+ * 约 9.3h 的 16kHz 音频在 addon 内一次性 resize 必崩）：
+ *  - 时长 ≤ 激活阈值（1.5h）→ null，走原单次转写路径（常规视频零变化）；
+ *  - 超阈值 → 按 ~1h 均衡片数定目标切点，每个切点在 ±45s 窗口内吸附到「最长静音 run 中点」
+ *    （避免把一句完整的话切成两段），ffmpeg 切片后返回带偏移的切片列表。
+ * WAV 头不可解析 → null（保持旧行为，交由 addon 自行处理）。
+ */
+export async function prepareBuiltinChunks(
+  audioPath: string,
+  opts?: { signal?: AbortSignal },
+): Promise<CloudAudioChunk[] | null> {
+  let info: WavInfo;
+  try {
+    info = readWavInfo(audioPath);
+  } catch (error) {
+    logMessage(
+      `builtin chunking: unreadable wav header, fallback to single pass (${error})`,
+      'warning',
+    );
+    return null;
+  }
+  const durationSec = info.durationMs / 1000;
+  const targets = planEvenChunkTargets(durationSec);
+  if (targets.length === 0) return null;
+
+  const cuts = targets.map((target) => {
+    const winStart = Math.max(0, target - CUT_SEARCH_WINDOW_SECONDS);
+    const winEnd = Math.min(durationSec, target + CUT_SEARCH_WINDOW_SECONDS);
+    try {
+      const window = windowFrameDb(audioPath, info, winStart, winEnd);
+      if (!window) return target;
+      return pickSilenceCut(
+        window.frameDb,
+        window.frameDurationSec,
+        winStart,
+        target,
+      );
+    } catch (error) {
+      logMessage(
+        `builtin chunking: window energy analysis failed at ${target.toFixed(1)}s, cutting at target (${error})`,
+        'warning',
+      );
+      return target;
+    }
+  });
+  const boundaries = boundariesFromCuts(durationSec, cuts);
+  if (boundaries.length < 2) return null;
+
+  logMessage(
+    `builtin long-audio chunking: ${durationSec.toFixed(0)}s -> ${boundaries.length} chunks [${boundaries
+      .map((b) => `${b.start.toFixed(1)}-${b.end.toFixed(1)}`)
+      .join(', ')}]`,
+    'info',
+  );
+  return splitWavAtBoundaries(audioPath, boundaries, opts);
 }
 
 /** 清理切片临时文件（跳过原始音频路径本身）。 */

--- a/main/helpers/builtinAudioChunking.ts
+++ b/main/helpers/builtinAudioChunking.ts
@@ -1,0 +1,237 @@
+/**
+ * 内置 whisper.cpp 引擎「超长音频分片转写」的纯逻辑（无 electron / fs / ffmpeg，便于 test:engines 单测）。
+ *
+ * 背景（12 小时视频转写秒崩，EXC_BREAKPOINT @ operator new）：addon 在 Electron 主进程内
+ * 一次性 `pcmf32.resize(总样本数)`——16kHz f32 单声道下约 9.3 小时即产生 ≥2GiB 的单笔分配，
+ * 被 Chromium PartitionAlloc 无条件 SIGTRAP（安全设计，不可关闭，且与空闲内存无关）；
+ * whisper 内部 VAD 还会整段复制音频，长文件内存成倍放大。
+ *
+ * 方案：超过激活阈值的音频在 JS 侧按「均衡目标时长 + 静音对齐」切片，逐片调用 addon 后
+ * 按偏移回拼 token / VAD 段 / 段级结果，喂给下游同一条成句管线（下游无感知）。
+ * 切点选在目标位置 ±CUT_SEARCH_WINDOW_SECONDS 窗口内「最长静音 run 的中点」，
+ * 保证不把一句完整的话切成两段；窗口内无可用静音（连续语流，极罕见）→ 退回目标位置。
+ */
+import {
+  formatTime,
+  parseTime,
+  type NativeToken,
+  type TokenTriple,
+} from './subtitleSegmentation';
+
+/** 单片目标时长（秒）：1 小时 ≈ 230MB float 缓冲，内存安全且模型重载开销可忽略。 */
+export const BUILTIN_CHUNK_TARGET_SECONDS = 3600;
+/**
+ * 分片激活阈值（秒）：短于 1.5 小时完全走原单次调用路径（常规视频零行为变化），
+ * 也避免 61 分钟这类文件被切出无意义的小尾片。
+ */
+export const BUILTIN_CHUNK_ACTIVATE_SECONDS = 5400;
+/** 切点搜索窗口半径（秒）：在目标切点 ±45s 内找静音；相对 1h 片长偏移可忽略。 */
+export const CUT_SEARCH_WINDOW_SECONDS = 45;
+/** 静音 run 最短时长（秒）：短于此视为词内间隙，不作为切点候选。 */
+export const MIN_SILENCE_RUN_SECONDS = 0.3;
+
+export interface ChunkPlanOptions {
+  targetSeconds?: number;
+  activateSeconds?: number;
+}
+
+/**
+ * 均衡切点目标位置（秒）：时长 ≤ 激活阈值 → 空数组（不分片）；
+ * 否则按 `ceil(duration/target)` 片数均分（避免贪心切法在结尾留超短尾片），
+ * 返回 count-1 个内部切点，后续再做静音对齐微调。
+ */
+export function planEvenChunkTargets(
+  durationSec: number,
+  options: ChunkPlanOptions = {},
+): number[] {
+  const target = options.targetSeconds ?? BUILTIN_CHUNK_TARGET_SECONDS;
+  const activate = options.activateSeconds ?? BUILTIN_CHUNK_ACTIVATE_SECONDS;
+  if (!Number.isFinite(durationSec) || durationSec <= activate || target <= 0) {
+    return [];
+  }
+  const count = Math.ceil(durationSec / target);
+  if (count < 2) return [];
+  const even = durationSec / count;
+  const targets: number[] = [];
+  for (let k = 1; k < count; k += 1) {
+    targets.push(k * even);
+  }
+  return targets;
+}
+
+/**
+ * 窗口静音判定阈值（dB）：窗口内最安静的 5% 帧视为真静音底噪，高出其 9dB 以内算静音帧，
+ * 并封顶 -38dB——若整个窗口都是连续语音（p5 也是语音电平），封顶保证不会把较轻的语音帧
+ * 误判成静音而切在句中；此时通常找不到合格静音 run，pickSilenceCut 退回目标位置。
+ */
+export function silenceThresholdDb(frameDb: number[]): number {
+  const sorted = (frameDb ?? [])
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => a - b);
+  if (!sorted.length) return -55;
+  const idx = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.round((sorted.length - 1) * 0.05)),
+  );
+  return Math.min(sorted[idx] + 9, -38);
+}
+
+export interface SilenceCutOptions {
+  /** 静音 run 最短时长（秒），默认 MIN_SILENCE_RUN_SECONDS。 */
+  minRunSeconds?: number;
+  /** 显式静音阈值（dB）；缺省用 silenceThresholdDb(frameDb) 自适应。 */
+  thresholdDb?: number;
+}
+
+/**
+ * 在能量帧窗口内挑静音切点（返回绝对秒）：收集低于阈值、时长 ≥ minRun 的静音 run，
+ * 取「最长者」（并列取离目标最近者）的中点——切在句间停顿正中，两侧词均不受损。
+ * 无合格 run → 返回 targetSec（退化为精确切，极罕见）。
+ */
+export function pickSilenceCut(
+  frameDb: number[],
+  frameDurationSec: number,
+  windowStartSec: number,
+  targetSec: number,
+  options: SilenceCutOptions = {},
+): number {
+  if (!frameDb?.length || !(frameDurationSec > 0)) return targetSec;
+  const threshold = options.thresholdDb ?? silenceThresholdDb(frameDb);
+  const minRun = options.minRunSeconds ?? MIN_SILENCE_RUN_SECONDS;
+  const minFrames = Math.max(1, Math.round(minRun / frameDurationSec));
+
+  interface Run {
+    start: number;
+    end: number; // 帧下标区间 [start, end)
+  }
+  const runs: Run[] = [];
+  let runStart = -1;
+  for (let i = 0; i < frameDb.length; i += 1) {
+    const silent = frameDb[i] < threshold;
+    if (silent && runStart < 0) runStart = i;
+    else if (!silent && runStart >= 0) {
+      runs.push({ start: runStart, end: i });
+      runStart = -1;
+    }
+  }
+  if (runStart >= 0) runs.push({ start: runStart, end: frameDb.length });
+
+  let best: Run | null = null;
+  let bestLen = 0;
+  let bestDist = Number.POSITIVE_INFINITY;
+  for (const run of runs) {
+    const len = run.end - run.start;
+    if (len < minFrames) continue;
+    const midSec =
+      windowStartSec + ((run.start + run.end) / 2) * frameDurationSec;
+    const dist = Math.abs(midSec - targetSec);
+    if (len > bestLen || (len === bestLen && dist < bestDist)) {
+      best = run;
+      bestLen = len;
+      bestDist = dist;
+    }
+  }
+  if (!best) return targetSec;
+  return windowStartSec + ((best.start + best.end) / 2) * frameDurationSec;
+}
+
+/**
+ * 切点 → 连续分片边界：过滤非法/越界切点并排序去重，跳过会产生 <1s 碎片的切点，
+ * 首尾补齐 [0, durationSec]。
+ */
+export function boundariesFromCuts(
+  durationSec: number,
+  cuts: number[],
+): Array<{ start: number; end: number }> {
+  if (!(durationSec > 0)) return [];
+  const valid = Array.from(
+    new Set(
+      (cuts ?? []).filter(
+        (c) => Number.isFinite(c) && c > 0 && c < durationSec,
+      ),
+    ),
+  ).sort((a, b) => a - b);
+  const boundaries: Array<{ start: number; end: number }> = [];
+  let prev = 0;
+  for (const cut of valid) {
+    if (cut - prev < 1 || durationSec - cut < 1) continue;
+    boundaries.push({ start: prev, end: cut });
+    prev = cut;
+  }
+  boundaries.push({ start: prev, end: durationSec });
+  return boundaries;
+}
+
+/** addon 免费暴露的 VAD 段原始形态（毫秒）。 */
+export interface RawVadSegment {
+  t0: number;
+  t1: number;
+}
+
+/** 逐 token 输出整体加偏移（毫秒）；时间非法的 token 原样保留（下游按无时间处理，不丢字）。 */
+export function offsetNativeTokens(
+  tokens: NativeToken[] | undefined,
+  offsetMs: number,
+): NativeToken[] {
+  return (tokens ?? []).map((tok) => {
+    const t0 = Number(tok?.t0);
+    const t1 = Number(tok?.t1);
+    return {
+      ...tok,
+      t0: Number.isFinite(t0) ? t0 + offsetMs : tok?.t0,
+      t1: Number.isFinite(t1) ? t1 + offsetMs : tok?.t1,
+    };
+  });
+}
+
+/** VAD 段整体加偏移（毫秒）；非法段原样保留（vadSegmentsToSpeech 会过滤）。 */
+export function offsetVadSegments(
+  segments: RawVadSegment[] | undefined,
+  offsetMs: number,
+): RawVadSegment[] {
+  return (segments ?? []).map((seg) => {
+    const t0 = Number(seg?.t0);
+    const t1 = Number(seg?.t1);
+    return {
+      t0: Number.isFinite(t0) ? t0 + offsetMs : seg?.t0,
+      t1: Number.isFinite(t1) ? t1 + offsetMs : seg?.t1,
+    };
+  });
+}
+
+/**
+ * 段级结果（[startStr, endStr, text]，旧加速包回退路径用）整体加偏移（秒）；
+ * 时间不可解析的条目原样保留文本。
+ */
+export function offsetSegmentCues(
+  cues: TokenTriple[] | undefined,
+  offsetSec: number,
+): TokenTriple[] {
+  return (cues ?? []).map((cue): TokenTriple => {
+    const start = parseTime(cue?.[0]);
+    const end = parseTime(cue?.[1]);
+    if (start === null || end === null) {
+      return [cue?.[0] ?? '', cue?.[1] ?? '', cue?.[2] ?? ''];
+    }
+    return [
+      formatTime(start + offsetSec),
+      formatTime(end + offsetSec),
+      cue?.[2] ?? '',
+    ];
+  });
+}
+
+/**
+ * 分片进度 → 整体进度（0–99）：单片 progress（0–100）按片序线性折算；
+ * 100 留给转写完成后的状态切换。
+ */
+export function chunkedProgressPercent(
+  chunkIndex: number,
+  chunkCount: number,
+  progress: number,
+): number {
+  if (!(chunkCount > 0)) return 0;
+  const p = Math.min(100, Math.max(0, Number(progress) || 0));
+  const overall = ((chunkIndex + p / 100) / chunkCount) * 100;
+  return Math.min(99, Math.max(0, Math.floor(overall)));
+}

--- a/main/helpers/builtinAudioChunking.ts
+++ b/main/helpers/builtinAudioChunking.ts
@@ -21,10 +21,12 @@ import {
 /** 单片目标时长（秒）：1 小时 ≈ 230MB float 缓冲，内存安全且模型重载开销可忽略。 */
 export const BUILTIN_CHUNK_TARGET_SECONDS = 3600;
 /**
- * 分片激活阈值（秒）：短于 1.5 小时完全走原单次调用路径（常规视频零行为变化），
- * 也避免 61 分钟这类文件被切出无意义的小尾片。
+ * 分片激活阈值（秒）：4 小时。常见长内容（电影/播客/讲座/赛事，≤3.5h）单次转写内存
+ * ≤~3GB 且一直工作正常，保持原路径零行为变化；>4h（直播录像/整套课程）恰是内存压力
+ * 真实出现的区间，且距 ~9.3h 的 PartitionAlloc 2GiB 崩溃红线留有 2.3 倍裕量
+ * （WAV 头损坏按字节数估算时长有偏差也安全）。
  */
-export const BUILTIN_CHUNK_ACTIVATE_SECONDS = 5400;
+export const BUILTIN_CHUNK_ACTIVATE_SECONDS = 14400;
 /** 切点搜索窗口半径（秒）：在目标切点 ±45s 内找静音；相对 1h 片长偏移可忽略。 */
 export const CUT_SEARCH_WINDOW_SECONDS = 45;
 /** 静音 run 最短时长（秒）：短于此视为词内间隙，不作为切点候选。 */

--- a/main/helpers/engines/builtinEngine.ts
+++ b/main/helpers/engines/builtinEngine.ts
@@ -253,7 +253,7 @@ async function transcribeBuiltin(ctx: TranscribeContext): Promise<string> {
       return merged;
     };
 
-    // 超长音频（>1.5h）先按静音对齐切片再转写：addon 在 Electron 主进程内一次性
+    // 超长音频（>4h）先按静音对齐切片再转写：addon 在 Electron 主进程内一次性
     // resize 整段 f32 缓冲，约 9.3h 起超过 PartitionAlloc 的 2GiB 单笔分配上限必崩
     // （SIGTRAP @ operator new，与空闲内存无关）；whisper 内部 VAD 还会整段复制音频。
     // 常规时长返回 null → 原单次调用路径，零行为变化。

--- a/main/helpers/engines/builtinEngine.ts
+++ b/main/helpers/engines/builtinEngine.ts
@@ -36,6 +36,19 @@ import {
   getNumericSetting,
 } from './transcribeShared';
 import { resolveEffectiveSettings } from './outcomePresets';
+import {
+  prepareBuiltinChunks,
+  cleanupCloudChunks,
+  type CloudAudioChunk,
+} from '../audioProcessor';
+import {
+  offsetNativeTokens,
+  offsetVadSegments,
+  offsetSegmentCues,
+  chunkedProgressPercent,
+  type RawVadSegment,
+} from '../builtinAudioChunking';
+import type { NativeToken, TokenTriple } from '../subtitleSegmentation';
 import type { TranscribeContext, TranscriptionEngineAdapter } from './types';
 
 /**
@@ -183,12 +196,83 @@ async function transcribeBuiltin(ctx: TranscribeContext): Promise<string> {
     );
     event.sender.send('taskProgressChange', file, 'extractSubtitle', 0);
     throwIfTaskCancelled();
-    startWatchdog();
+
+    // 逐片转写 + 按偏移回拼（token/VAD 段为毫秒、段级回退为秒），输出与单次调用同构，
+    // 下游成句管线无感知。任一片取消 → 返回 cancelled 结果，走统一取消清理。
+    const transcribeChunked = async (chunkList: CloudAudioChunk[]) => {
+      const merged = {
+        tokens: [] as NativeToken[],
+        vadSegments: [] as RawVadSegment[],
+        transcription: [] as TokenTriple[],
+      };
+      for (let i = 0; i < chunkList.length; i += 1) {
+        const chunk = chunkList[i];
+        throwIfTaskCancelled();
+        logMessage(
+          `builtin chunk ${i + 1}/${chunkList.length}: ${chunk.startOffsetSec.toFixed(1)}s -> ${chunk.endOffsetSec.toFixed(1)}s`,
+          'info',
+        );
+        const chunkParams = {
+          ...whisperParams,
+          fname_inp: chunk.path,
+          progress_callback: (progress: number) => {
+            clearWatchdog();
+            if (signal?.aborted) return;
+            event.sender.send(
+              'taskProgressChange',
+              file,
+              'extractSubtitle',
+              chunkedProgressPercent(i, chunkList.length, progress),
+            );
+          },
+        };
+        startWatchdog();
+        let chunkResult;
+        try {
+          chunkResult = await whisperAsync(chunkParams);
+        } finally {
+          clearWatchdog();
+        }
+        if (isWhisperCancelledResult(chunkResult) || signal?.aborted) {
+          return { cancelled: true };
+        }
+        const offsetMs = Math.round(chunk.startOffsetSec * 1000);
+        merged.tokens.push(
+          ...offsetNativeTokens(chunkResult?.tokens, offsetMs),
+        );
+        merged.vadSegments.push(
+          ...offsetVadSegments(chunkResult?.vadSegments, offsetMs),
+        );
+        merged.transcription.push(
+          ...offsetSegmentCues(
+            chunkResult?.transcription,
+            chunk.startOffsetSec,
+          ),
+        );
+      }
+      return merged;
+    };
+
+    // 超长音频（>1.5h）先按静音对齐切片再转写：addon 在 Electron 主进程内一次性
+    // resize 整段 f32 缓冲，约 9.3h 起超过 PartitionAlloc 的 2GiB 单笔分配上限必崩
+    // （SIGTRAP @ operator new，与空闲内存无关）；whisper 内部 VAD 还会整段复制音频。
+    // 常规时长返回 null → 原单次调用路径，零行为变化。
+    const chunks = await prepareBuiltinChunks(tempAudioFile, { signal });
+
     let result;
-    try {
-      result = await whisperAsync(whisperParams);
-    } finally {
-      clearWatchdog();
+    if (chunks) {
+      try {
+        result = await transcribeChunked(chunks);
+      } finally {
+        cleanupCloudChunks(chunks, tempAudioFile);
+      }
+    } else {
+      startWatchdog();
+      try {
+        result = await whisperAsync(whisperParams);
+      } finally {
+        clearWatchdog();
+      }
     }
 
     if (isWhisperCancelledResult(result) || signal?.aborted) {

--- a/main/helpers/subtitleSegmentation.ts
+++ b/main/helpers/subtitleSegmentation.ts
@@ -139,8 +139,8 @@ function wordBoundaryOffsets(text: string): Set<number> | null {
   return bounds;
 }
 
-/** 把 `HH:MM:SS.mmm` / `MM:SS` / 纯秒（逗号或点皆可）解析为秒；非法返回 null。 */
-function parseTime(time?: string): number | null {
+/** 把 `HH:MM:SS.mmm` / `MM:SS` / 纯秒（逗号或点皆可）解析为秒；非法返回 null。导出供纯逻辑模块复用。 */
+export function parseTime(time?: string): number | null {
   if (!time) return null;
   const normalized = time.trim().replace(',', '.');
   const parts = normalized.split(':').map((part) => Number(part));

--- a/main/helpers/subtitleTiming.ts
+++ b/main/helpers/subtitleTiming.ts
@@ -209,7 +209,14 @@ export function energySpeechSegments(
   audioFile?: string,
 ): Array<{ start: number; end: number }> {
   if (!audioFile || !fs.existsSync(audioFile)) return [];
-  const energy = analyzePcm16WavEnergy(audioFile);
+  let energy: AudioEnergy | null = null;
+  try {
+    energy = analyzePcm16WavEnergy(audioFile);
+  } catch (error) {
+    // 与文档合同一致：解析失败（如 >2GiB WAV 超出 readFileSync 上限）→ []，调用方降级。
+    logMessage(`energy speech segments skipped: ${error}`, 'warning');
+    return [];
+  }
   if (!energy) return [];
   const { frameDb, frameDurationSeconds: fd, thresholdDb } = energy;
 

--- a/main/helpers/wavWindowEnergy.ts
+++ b/main/helpers/wavWindowEnergy.ts
@@ -1,0 +1,92 @@
+/**
+ * PCM16 WAV「时间窗」能量分析（fs 定位读取，无 electron 依赖，便于 test:engines 单测）。
+ *
+ * 与 subtitleTiming.analyzePcm16WavEnergy 的差别：那边整读文件算全局能量/阈值；
+ * 这里只读窗口字节——超长 WAV（12h≈1.4GB，18h+ 超过 Buffer/分配器上限）整读既慢又可能崩，
+ * 而内置引擎分片切点只需要目标位置附近 ±45s 的能量。
+ */
+import fs from 'fs';
+
+/** PCM WAV 数据布局（dubbing/audioPipeline.readWavInfo 的返回值结构兼容此接口）。 */
+export interface PcmWavLayout {
+  sampleRate: number;
+  channels: number;
+  bitsPerSample: number;
+  /** data chunk 起始偏移（字节）。 */
+  dataOffset: number;
+  /** data chunk 字节数。 */
+  dataBytes: number;
+}
+
+const ENERGY_FRAME_MS = 20;
+
+/**
+ * 读取 [startSec, endSec) 窗口的 PCM16 采样并计算 20ms 帧 RMS 能量（dB）。
+ * 非 PCM16 / 窗口越界 / 读取为空 → null（调用方退回精确切点）。
+ */
+export function windowFrameDb(
+  audioPath: string,
+  layout: PcmWavLayout,
+  startSec: number,
+  endSec: number,
+): { frameDb: number[]; frameDurationSec: number } | null {
+  if (
+    layout.bitsPerSample !== 16 ||
+    layout.channels <= 0 ||
+    layout.sampleRate <= 0
+  ) {
+    return null;
+  }
+  const bytesPerSampleFrame = 2 * layout.channels;
+  const totalFrames = Math.floor(layout.dataBytes / bytesPerSampleFrame);
+  const startFrame = Math.min(
+    totalFrames,
+    Math.max(0, Math.floor(startSec * layout.sampleRate)),
+  );
+  const endFrame = Math.min(
+    totalFrames,
+    Math.max(startFrame, Math.ceil(endSec * layout.sampleRate)),
+  );
+  if (endFrame <= startFrame) return null;
+
+  const byteLength = (endFrame - startFrame) * bytesPerSampleFrame;
+  const buffer = Buffer.alloc(byteLength);
+  let bytesRead = 0;
+  const fd = fs.openSync(audioPath, 'r');
+  try {
+    bytesRead = fs.readSync(
+      fd,
+      buffer,
+      0,
+      byteLength,
+      layout.dataOffset + startFrame * bytesPerSampleFrame,
+    );
+  } finally {
+    fs.closeSync(fd);
+  }
+  const availFrames = Math.floor(bytesRead / bytesPerSampleFrame);
+  if (availFrames <= 0) return null;
+
+  const samplesPerEnergyFrame = Math.max(
+    1,
+    Math.round((layout.sampleRate * ENERGY_FRAME_MS) / 1000),
+  );
+  const frameDurationSec = samplesPerEnergyFrame / layout.sampleRate;
+  const frameDb: number[] = [];
+  for (let frame = 0; frame < availFrames; frame += samplesPerEnergyFrame) {
+    const last = Math.min(availFrames, frame + samplesPerEnergyFrame);
+    let sumSquares = 0;
+    let count = 0;
+    for (let sampleFrame = frame; sampleFrame < last; sampleFrame += 1) {
+      for (let channel = 0; channel < layout.channels; channel += 1) {
+        const byteOffset = (sampleFrame * layout.channels + channel) * 2;
+        const sample = buffer.readInt16LE(byteOffset) / 32768;
+        sumSquares += sample * sample;
+        count += 1;
+      }
+    }
+    const rms = Math.sqrt(sumSquares / Math.max(count, 1));
+    frameDb.push(20 * Math.log10(Math.max(rms, 1e-8)));
+  }
+  return frameDb.length ? { frameDb, frameDurationSec } : null;
+}

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -3485,6 +3485,11 @@ eq(
   'builtin chunk: 1h below activate threshold -> no chunking',
 );
 eq(
+  planEvenChunkTargets(10800),
+  [],
+  'builtin chunk: common long content (3h movie/podcast) keeps single pass',
+);
+eq(
   planEvenChunkTargets(BUILTIN_CHUNK_ACTIVATE_SECONDS),
   [],
   'builtin chunk: exactly at activate threshold -> no chunking',
@@ -3495,9 +3500,9 @@ eq(
   'builtin chunk: 12h -> 11 even cut targets (12 chunks of 1h)',
 );
 eq(
-  planEvenChunkTargets(5401),
-  [2700.5],
-  'builtin chunk: just above threshold -> two balanced halves (no tiny tail)',
+  planEvenChunkTargets(15000),
+  [3000, 6000, 9000, 12000],
+  'builtin chunk: just above threshold -> balanced chunks (no tiny tail)',
 );
 eq(
   planEvenChunkTargets(7000, { targetSeconds: 3600, activateSeconds: 5400 }),

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -136,6 +136,18 @@ import {
 } from '../renderer/lib/engineViews';
 import { computeChunkBoundaries } from '../main/helpers/cloudAudioChunking';
 import {
+  planEvenChunkTargets,
+  silenceThresholdDb,
+  pickSilenceCut,
+  boundariesFromCuts,
+  offsetNativeTokens,
+  offsetVadSegments,
+  offsetSegmentCues,
+  chunkedProgressPercent,
+  BUILTIN_CHUNK_ACTIVATE_SECONDS,
+} from '../main/helpers/builtinAudioChunking';
+import { windowFrameDb } from '../main/helpers/wavWindowEnergy';
+import {
   needsSpaceBefore,
   realignPunctuation,
   wordsToNativeTokens,
@@ -3465,6 +3477,237 @@ eq(
   ],
   'chunk: exceeding limit splits at silence midpoints',
 );
+
+// --- builtinAudioChunking: planEvenChunkTargets ---
+eq(
+  planEvenChunkTargets(3600),
+  [],
+  'builtin chunk: 1h below activate threshold -> no chunking',
+);
+eq(
+  planEvenChunkTargets(BUILTIN_CHUNK_ACTIVATE_SECONDS),
+  [],
+  'builtin chunk: exactly at activate threshold -> no chunking',
+);
+eq(
+  planEvenChunkTargets(43200),
+  [3600, 7200, 10800, 14400, 18000, 21600, 25200, 28800, 32400, 36000, 39600],
+  'builtin chunk: 12h -> 11 even cut targets (12 chunks of 1h)',
+);
+eq(
+  planEvenChunkTargets(5401),
+  [2700.5],
+  'builtin chunk: just above threshold -> two balanced halves (no tiny tail)',
+);
+eq(
+  planEvenChunkTargets(7000, { targetSeconds: 3600, activateSeconds: 5400 }),
+  [3500],
+  'builtin chunk: ceil-balanced targets keep chunks under target size',
+);
+eq(planEvenChunkTargets(NaN), [], 'builtin chunk: invalid duration -> []');
+
+// --- builtinAudioChunking: silenceThresholdDb ---
+eq(silenceThresholdDb([]), -55, 'builtin chunk: empty frames -> default');
+eq(
+  silenceThresholdDb(Array(100).fill(-70)),
+  -61,
+  'builtin chunk: quiet floor -> floor + 9dB',
+);
+eq(
+  silenceThresholdDb(Array(100).fill(-20)),
+  -38,
+  'builtin chunk: loud continuous speech -> capped at -38dB',
+);
+
+// --- builtinAudioChunking: pickSilenceCut ---
+{
+  // 20ms 帧、窗口起点 100s：语音 -20dB，帧 400–500 为 -70dB 静音 run（108–110s，中点 109s）
+  const frames = Array(1000).fill(-20);
+  for (let i = 400; i < 500; i += 1) frames[i] = -70;
+  eq(
+    pickSilenceCut(frames, 0.02, 100, 105),
+    109,
+    'builtin chunk: cut lands at midpoint of longest silence run',
+  );
+  // 两个静音 run：更长者胜出（帧 100–150 中点 102.5s vs 帧 700–900 中点 116s）
+  const twoRuns = Array(1000).fill(-20);
+  for (let i = 100; i < 150; i += 1) twoRuns[i] = -70;
+  for (let i = 700; i < 900; i += 1) twoRuns[i] = -70;
+  eq(
+    pickSilenceCut(twoRuns, 0.02, 100, 103),
+    116,
+    'builtin chunk: longer silence run wins over nearer short one',
+  );
+  // 全程语音（无合格静音 run）→ 退回目标位置
+  eq(
+    pickSilenceCut(Array(1000).fill(-20), 0.02, 100, 105),
+    105,
+    'builtin chunk: continuous speech window falls back to target cut',
+  );
+  // 短于 minRun 的间隙不算切点
+  const shortGap = Array(1000).fill(-20);
+  for (let i = 500; i < 510; i += 1) shortGap[i] = -70; // 0.2s < 0.3s
+  eq(
+    pickSilenceCut(shortGap, 0.02, 100, 105),
+    105,
+    'builtin chunk: sub-minimum silence gap is not a cut candidate',
+  );
+}
+
+// --- builtinAudioChunking: boundariesFromCuts ---
+eq(
+  boundariesFromCuts(100, [30, 60]),
+  [
+    { start: 0, end: 30 },
+    { start: 30, end: 60 },
+    { start: 60, end: 100 },
+  ],
+  'builtin chunk: cuts -> contiguous boundaries',
+);
+eq(
+  boundariesFromCuts(100, [60, 30, 60, NaN, -5, 200]),
+  [
+    { start: 0, end: 30 },
+    { start: 30, end: 60 },
+    { start: 60, end: 100 },
+  ],
+  'builtin chunk: boundaries dedupe/sort and drop invalid cuts',
+);
+eq(
+  boundariesFromCuts(100, [0.5, 99.5]),
+  [{ start: 0, end: 100 }],
+  'builtin chunk: cuts creating <1s fragments are skipped',
+);
+eq(boundariesFromCuts(0, [10]), [], 'builtin chunk: no duration -> []');
+
+// --- builtinAudioChunking: offset merge helpers ---
+eq(
+  offsetNativeTokens(
+    [
+      { text: ' Hello', t0: 100, t1: 500, p: 0.9 },
+      { text: ' world', t0: NaN, t1: 800 },
+    ],
+    3600000,
+  ),
+  [
+    { text: ' Hello', t0: 3600100, t1: 3600500, p: 0.9 },
+    { text: ' world', t0: NaN, t1: 3600800 },
+  ],
+  'builtin chunk: token offset in ms, invalid times preserved',
+);
+eq(
+  offsetVadSegments([{ t0: 0, t1: 1500 }], 7200000),
+  [{ t0: 7200000, t1: 7201500 }],
+  'builtin chunk: vad segment offset in ms',
+);
+eq(
+  offsetSegmentCues(
+    [
+      ['00:00:01,000', '00:00:02,500', 'hi'],
+      ['bogus', '00:00:03,000', 'kept'],
+    ],
+    3600,
+  ),
+  [
+    ['01:00:01,000', '01:00:02,500', 'hi'],
+    ['bogus', '00:00:03,000', 'kept'],
+  ],
+  'builtin chunk: segment cue offset in sec, unparseable kept as-is',
+);
+
+// --- builtinAudioChunking: chunkedProgressPercent ---
+eq(
+  chunkedProgressPercent(0, 12, 50),
+  4,
+  'builtin chunk: progress scales within first chunk',
+);
+eq(
+  chunkedProgressPercent(6, 12, 0),
+  50,
+  'builtin chunk: chunk index maps to overall baseline',
+);
+eq(
+  chunkedProgressPercent(11, 12, 100),
+  99,
+  'builtin chunk: final chunk caps at 99 until done',
+);
+eq(chunkedProgressPercent(0, 0, 50), 0, 'builtin chunk: zero chunks -> 0');
+
+// --- wavWindowEnergy: windowFrameDb（合成 WAV：窗口读取 + 静音切点端到端） ---
+{
+  const writeTestWav = (
+    file: string,
+    samples: Int16Array,
+    sampleRate: number,
+  ) => {
+    const header = Buffer.alloc(44);
+    header.write('RIFF', 0, 'ascii');
+    header.writeUInt32LE(36 + samples.length * 2, 4);
+    header.write('WAVE', 8, 'ascii');
+    header.write('fmt ', 12, 'ascii');
+    header.writeUInt32LE(16, 16);
+    header.writeUInt16LE(1, 20); // PCM
+    header.writeUInt16LE(1, 22); // mono
+    header.writeUInt32LE(sampleRate, 24);
+    header.writeUInt32LE(sampleRate * 2, 28);
+    header.writeUInt16LE(2, 32);
+    header.writeUInt16LE(16, 34);
+    header.write('data', 36, 'ascii');
+    header.writeUInt32LE(samples.length * 2, 40);
+    fs.writeFileSync(
+      file,
+      Buffer.concat([
+        header,
+        Buffer.from(samples.buffer, samples.byteOffset, samples.byteLength),
+      ]),
+    );
+  };
+
+  // 4s @16kHz 单声道：全程"语音"（幅值 6000），1.5s–2.5s 为纯静音
+  const sampleRate = 16000;
+  const samples = new Int16Array(4 * sampleRate).fill(6000);
+  samples.fill(0, 1.5 * sampleRate, 2.5 * sampleRate);
+  const wavPath = nodePath.join(os.tmpdir(), `smartsub-test-${Date.now()}.wav`);
+  writeTestWav(wavPath, samples, sampleRate);
+  const layout = {
+    sampleRate,
+    channels: 1,
+    bitsPerSample: 16,
+    dataOffset: 44,
+    dataBytes: samples.length * 2,
+  };
+
+  const window = windowFrameDb(wavPath, layout, 1, 3);
+  eq(window !== null, true, 'wav window: analyzable window returns frames');
+  eq(
+    window!.frameDb.length,
+    100,
+    'wav window: 2s window at 20ms frames -> 100 frames',
+  );
+  eq(
+    Math.abs(window!.frameDurationSec - 0.02) < 1e-9,
+    true,
+    'wav window: frame duration is 20ms',
+  );
+  // 端到端：窗口能量 → 静音切点落在静音区正中（2.0s），而不是目标位置（1.8s）
+  eq(
+    pickSilenceCut(window!.frameDb, window!.frameDurationSec, 1, 1.8),
+    2,
+    'wav window: end-to-end cut lands at silence midpoint, not mid-sentence',
+  );
+
+  eq(
+    windowFrameDb(wavPath, { ...layout, bitsPerSample: 32 }, 1, 3),
+    null,
+    'wav window: non-PCM16 layout rejected',
+  );
+  eq(
+    windowFrameDb(wavPath, layout, 10, 12),
+    null,
+    'wav window: window beyond data -> null',
+  );
+  fs.unlinkSync(wavPath);
+}
 
 // --- cloudAsrShared: needsSpaceBefore ---
 eq(needsSpaceBefore('Hello'), true, 'asr: latin word needs leading space');


### PR DESCRIPTION
## 问题

内置 whisper.cpp 引擎转写超长媒体（如 12 小时课程视频）时应用整体闪退（EXC_BREAKPOINT / SIGTRAP，崩在 `read_audio_from_decoder` 的 `operator new`），且因临时 WAV 按路径 md5 缓存，重试必然复现。

根因：addon 在 Electron 主进程内把整段音频一次性 `pcmf32.resize(总样本数)` 读进单个连续 f32 缓冲。16kHz 单声道下约 **9.3 小时** 即产生 ≥2GiB 的单笔分配，被 Chromium PartitionAlloc 无条件拒绝并故意触发崩溃（安全设计、不可关闭、与空闲内存无关，参见 electron/electron#44291）；whisper 内部 VAD 还会整段复制音频，长文件内存成倍放大。

## 方案

超过 **4 小时** 的音频在 JS 侧先按静音对齐切片，逐片调用 addon 后按偏移回拼，下游成句管线无感知：

- **切片计划**：按 `ceil(时长/3600)` 均衡分片（12h → 12 片约 1h），不产生小尾片；单片 f32 缓冲仅约 230MB。
- **静音吸附切点（不切断句子）**：每个均衡目标切点在 ±45s 窗口内做 20ms 帧能量扫描，取最长静音 run（≥0.3s）的中点；窗口全是连续语流时退回精确位置。阈值自适应（最安静 5% 帧 +9dB，封顶 -38dB），不会把轻声说话误判为静音。
- **窗口能量只读窗口字节**（`fs.readSync` 定位读取），不整读文件——18h+ 的 WAV 整读本身就会再撞分配上限。
- **结果回拼**：token / VAD 段（毫秒）、段级回退（秒）按片偏移平移合并，输出与单次调用同构；进度按片折算；取消走统一清理；切片临时文件 finally 清除。
- **阈值取 4h**：常见长内容（电影/播客/讲座/赛事，≤3.5h）保持原单次路径零行为变化；>4h（直播录像/整套课程）恰是内存压力真实出现的区间，距 9.3h 崩溃红线留 2.3 倍裕量。≤4h 文件唯一的新开销是一次 WAV 头读取。

另外两处顺带收敛：`energySpeechSegments` 对齐其文档合同（解析失败返回 `[]` 而非抛错，>2GiB WAV 会超 `readFileSync` 上限）；ffmpeg 切片执行器与云端 `splitBySilence` 共用。

## 变更

- 新增 `main/helpers/builtinAudioChunking.ts`：切片规划/静音切点/偏移回拼/进度折算（纯函数）
- 新增 `main/helpers/wavWindowEnergy.ts`：PCM16 WAV 时间窗能量分析（定位读取）
- `audioProcessor.ts`：`prepareBuiltinChunks`（时长探测 → 切点规划 → ffmpeg 切片）
- `engines/builtinEngine.ts`：分片转写循环（看门狗按片重启、进度、取消、清理）
- `subtitleTiming.ts` / `subtitleSegmentation.ts`：小幅收敛（见上）与 `parseTime` 导出

## 测试

- [x] `npm run test:engines`：686 项全部通过（新增 31 项：切片规划边界、静音切点挑选、偏移回拼、进度折算，以及合成 WAV 的端到端「切点落在静音正中」验证）
- [x] `tsc --noEmit` 对改动文件无新增错误
- [ ] 手动冒烟：>4h 视频观察日志 `builtin long-audio chunking: ... -> N chunks`，确认片界处字幕时间轴连续、无句子被切断