### PR TITLE
修复 Deepgram 日语标点前置与异常断句

### DIFF
--- a/main/helpers/engines/cloudAsrShared.ts
+++ b/main/helpers/engines/cloudAsrShared.ts
@@ -24,10 +24,13 @@ export function needsSpaceBefore(token: string): boolean {
   return /^[A-Za-z0-9]/.test(token);
 }
 
+const PUNCTUATION_OR_SYMBOL_ONLY = /^[\p{P}\p{S}]+$/u;
+
 /**
  * 标点回贴（best-effort）：whisper-1 的词级时间戳（尤其中文）不含标点，但整段 `text` 含标点。
  * 在 fullText 里按序定位每个 word，把 word 间/尾部出现的标点补回「前一个 word」文本，
- * 使成句后的字幕带上自然标点。定位失败的 word 跳过（不误贴、不丢词）。
+ * 使成句后的字幕带上自然标点。只有纯标点/符号的间隙才会回贴，定位失败产生的正文间隙
+ * 会被忽略，避免重复字幕文本。
  */
 export function realignPunctuation(
   words: AsrWord[],
@@ -44,13 +47,13 @@ export function realignPunctuation(
     const idx = text.indexOf(token, cursor);
     if (idx < 0) continue; // 定位失败：跳过该 word（不改动）
     const gap = text.slice(cursor, idx).replace(/\s+/g, '');
-    if (gap && i > 0) {
+    if (gap && i > 0 && PUNCTUATION_OR_SYMBOL_ONLY.test(gap)) {
       result[i - 1].word = String(result[i - 1].word ?? '') + gap;
     }
     cursor = idx + token.length;
   }
   const tail = text.slice(cursor).replace(/\s+/g, '');
-  if (tail) {
+  if (tail && PUNCTUATION_OR_SYMBOL_ONLY.test(tail)) {
     result[result.length - 1].word =
       String(result[result.length - 1].word ?? '') + tail;
   }

--- a/main/service/asr/deepgramUtils.ts
+++ b/main/service/asr/deepgramUtils.ts
@@ -20,10 +20,14 @@ function reattachLeadingClosingPunctuation(
   previous?: AsrWord,
 ): string {
   if (!previous) return word;
-  const matched = word.match(LEADING_CLOSING_PUNCTUATION);
-  if (!matched) return word;
-  previous.word = `${previous.word}${matched[1]}`;
-  return matched[2];
+  let remaining = word;
+  let matched = remaining.match(LEADING_CLOSING_PUNCTUATION);
+  while (matched) {
+    previous.word = `${previous.word}${matched[1]}`;
+    remaining = matched[2];
+    matched = remaining.match(LEADING_CLOSING_PUNCTUATION);
+  }
+  return remaining;
 }
 
 /**

--- a/main/service/asr/deepgramUtils.ts
+++ b/main/service/asr/deepgramUtils.ts
@@ -6,6 +6,27 @@ import type { AsrWord } from './types';
 const DEEPGRAM_DEFAULT_BASE = 'https://api.deepgram.com/v1';
 
 /**
+ * Deepgram 的日语 punctuated_word 偶尔会把上一句的收尾标点放到下一个词前面，
+ * 例如 plain word 为「次」而 punctuated_word 为「。次」。成句器只会把纯标点 token
+ * 贴回上一条，因此这里先把「收尾标点 + 正文」拆开并归还给前一个词。
+ *
+ * 左引号（「『“）不在集合内，避免把新一句的开引号错误移到上一句。
+ */
+const LEADING_CLOSING_PUNCTUATION =
+  /^((?:[。．!！?？…，,、:：;；]+["'」』”’）)\]】》〉〕］}]*|[」』”’）)\]】》〉〕］}]+))(.+)$/u;
+
+function reattachLeadingClosingPunctuation(
+  word: string,
+  previous?: AsrWord,
+): string {
+  if (!previous) return word;
+  const matched = word.match(LEADING_CLOSING_PUNCTUATION);
+  if (!matched) return word;
+  previous.word = `${previous.word}${matched[1]}`;
+  return matched[2];
+}
+
+/**
  * 规范化 Base URL：空/非法 → 官方默认；去除误粘的 /listen 后缀；去尾部斜杠。
  * base 非必填，缺省回落官方端点。
  */
@@ -58,7 +79,11 @@ export function mapDeepgramWords(raw: unknown): AsrWord[] {
     const start = Number((w as { start?: unknown })?.start);
     const end = Number((w as { end?: unknown })?.end);
     if (Number.isFinite(start) && Number.isFinite(end)) {
-      out.push({ word, start, end });
+      const normalizedWord = reattachLeadingClosingPunctuation(
+        word,
+        out[out.length - 1],
+      );
+      if (normalizedWord) out.push({ word: normalizedWord, start, end });
     }
   }
   return out;

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -4176,6 +4176,56 @@ eq(
   [{ word: 'plain', start: 1, end: 2 }],
   'deepgram: falls back to word when no punctuated_word',
 );
+eq(
+  mapDeepgramWords([
+    { word: 'これは', punctuated_word: '「これは', start: 0, end: 1 },
+    { word: '次', punctuated_word: '。」次', start: 1, end: 2 },
+    { word: 'です', punctuated_word: 'です。', start: 2, end: 3 },
+  ]),
+  [
+    { word: '「これは。」', start: 0, end: 1 },
+    { word: '次', start: 1, end: 2 },
+    { word: 'です。', start: 2, end: 3 },
+  ],
+  'deepgram: Japanese leading closing punctuation reattaches to previous word (#391)',
+);
+eq(
+  mapDeepgramWords([
+    { word: '前', punctuated_word: '前。', start: 0, end: 1 },
+    { word: '次', punctuated_word: '「次', start: 1, end: 2 },
+  ]),
+  [
+    { word: '前。', start: 0, end: 1 },
+    { word: '「次', start: 1, end: 2 },
+  ],
+  'deepgram: Japanese opening quote remains with the following word',
+);
+eq(
+  mapDeepgramWords([
+    { word: 'Use', punctuated_word: 'Use', start: 0, end: 1 },
+    { word: '.NET', punctuated_word: '.NET', start: 1, end: 2 },
+  ]),
+  [
+    { word: 'Use', start: 0, end: 1 },
+    { word: '.NET', start: 1, end: 2 },
+  ],
+  'deepgram: lexical ASCII leading period is not reattached',
+);
+eq(
+  wordCuesFromResult({
+    words: mapDeepgramWords([
+      { word: 'これは', punctuated_word: 'これは', start: 0, end: 1 },
+      { word: '次', punctuated_word: '。次', start: 1, end: 2 },
+      { word: 'です', punctuated_word: 'です。', start: 2, end: 3 },
+    ]),
+    text: 'これは。次です。',
+  }),
+  [
+    ['00:00:00,000', '00:00:01,000', 'これは。'],
+    ['00:00:01,000', '00:00:03,000', '次です。'],
+  ],
+  'deepgram: Japanese leading punctuation produces natural sentence cues (#391)',
+);
 
 // --- deepgramUtils: extractDeepgramResult (nested structure) ---
 eq(

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -3891,6 +3891,28 @@ eq(
   ['x'],
   'asr: realign with empty fullText is a no-op',
 );
+eq(
+  realignPunctuation(
+    [
+      { word: 'これは。', start: 0, end: 1 },
+      { word: '次', start: 1, end: 2 },
+    ],
+    'これは 。次',
+  ).map((w) => w.word),
+  ['これは。', '次'],
+  'asr: realign ignores a gap containing transcript text',
+);
+eq(
+  realignPunctuation(
+    [
+      { word: 'known', start: 0, end: 1 },
+      { word: 'missing', start: 1, end: 2 },
+    ],
+    'known trailing text.',
+  ).map((w) => w.word),
+  ['known', 'missing'],
+  'asr: realign ignores a tail containing transcript text',
+);
 
 // --- cloudAsrShared: offsetWords ---
 eq(
@@ -4191,6 +4213,17 @@ eq(
 );
 eq(
   mapDeepgramWords([
+    { word: 'これは', punctuated_word: '「これは', start: 0, end: 1 },
+    { word: '次', punctuated_word: '」。次', start: 1, end: 2 },
+  ]),
+  [
+    { word: '「これは」。', start: 0, end: 1 },
+    { word: '次', start: 1, end: 2 },
+  ],
+  'deepgram: Japanese closing quote then period both reattach to previous word',
+);
+eq(
+  mapDeepgramWords([
     { word: '前', punctuated_word: '前。', start: 0, end: 1 },
     { word: '次', punctuated_word: '「次', start: 1, end: 2 },
   ]),
@@ -4218,13 +4251,14 @@ eq(
       { word: '次', punctuated_word: '。次', start: 1, end: 2 },
       { word: 'です', punctuated_word: 'です。', start: 2, end: 3 },
     ]),
-    text: 'これは。次です。',
+    // Deepgram 的真实 transcript 由 punctuated_word 以空格连接。
+    text: 'これは 。次 です。',
   }),
   [
     ['00:00:00,000', '00:00:01,000', 'これは。'],
     ['00:00:01,000', '00:00:03,000', '次です。'],
   ],
-  'deepgram: Japanese leading punctuation produces natural sentence cues (#391)',
+  'deepgram: works with real space-joined transcript (#391)',
 );
 
 // --- deepgramUtils: extractDeepgramResult (nested structure) ---


### PR DESCRIPTION
## 变更内容

- 在 Deepgram 词级结果归一化阶段识别“句末标点/闭合引号 + 下一词”的混合 `punctuated_word`。
- 将错误位于下一词开头的句末标点归还给前一个词，让现有成句器在正确位置断句。
- 保留新句左引号及 `.NET` 等以 ASCII 句点开头的实际词汇，避免扩大修复范围。
- 增加日语句号、右引号、左引号保护和最终字幕断句的回归测试。

## 问题原因

Deepgram 的日语结果可能把上一句的收尾标点放到下一个文字 token 前面，例如普通词为“次”，但 `punctuated_word` 为“。次”。现有成句逻辑只能处理位于 token 末尾或独立成 token 的标点，因此会错过句界，并可能生成以标点开头的字幕。

## 用户影响

Deepgram 日语转写会在标点所属的自然句界处生成字幕，减少行首标点和不自然断句，无需依赖后续 AI 校对修正该结构问题。

## 验证

- `npm run test:engines`：704 passed，0 failed
- `npx prettier --check main/service/asr/deepgramUtils.ts scripts/test-engine-units.ts`：通过
- `npm run check:i18n`：通过
- `npm run build`：Renderer、类型检查及 36 个静态页面生成通过；Main process 在本地既有 Webpack/Nextron 版本冲突处失败（`IgnorePlugin.apply` 读取 `compiler.hooks.validate` 时为空），与本次纯工具函数修改无关

Closes #391
