### PR TITLE
fix: 支持 Qwen-MT 单用户消息结构

### DIFF
--- a/main/service/openai.ts
+++ b/main/service/openai.ts
@@ -21,6 +21,10 @@ import {
   appendNoThinkSoftSwitch,
   extractOpenAIResponseMeta,
 } from './thinkingControl';
+import {
+  buildOpenAIRequestMessages,
+  type OpenAIMessageLayout,
+} from './openaiMessageLayout';
 
 type OpenAIProvider = {
   apiUrl: string;
@@ -34,6 +38,7 @@ type OpenAIProvider = {
   providerType?: string;
   id?: string;
   enableThinking?: boolean;
+  messageLayout?: OpenAIMessageLayout;
 };
 
 /**
@@ -199,10 +204,12 @@ function createBaseParams(text: string | string[], provider: OpenAIProvider) {
 
   const baseParams = {
     model: provider.modelName || 'gpt-3.5-turbo',
-    messages: [
-      { role: 'system', content: sysPrompt },
-      { role: 'user', content: userPrompt },
-    ] as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
+    messages: buildOpenAIRequestMessages(
+      sysPrompt,
+      userPrompt,
+      provider.messageLayout,
+      provider.modelName,
+    ) as OpenAI.Chat.Completions.ChatCompletionMessageParam[],
     temperature: 0.3,
     stream: false,
     ...getProviderSpecificParams(provider),

--- a/main/service/openaiMessageLayout.ts
+++ b/main/service/openaiMessageLayout.ts
@@ -1,0 +1,56 @@
+export type OpenAIMessageLayout = 'auto' | 'system_user' | 'single_user';
+
+export type OpenAIRequestMessage = {
+  role: 'system' | 'user';
+  content: string;
+};
+
+/**
+ * Qwen-MT 的 OpenAI 兼容接口只接受一条 user 消息，不支持 system 消息。
+ * 自动模式仅匹配明确的 qwen-mt 型号，避免改变普通 Qwen/DeepSeek/OpenAI 模型。
+ */
+export function requiresSingleUserMessage(modelName?: string): boolean {
+  const normalized = String(modelName || '')
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-');
+  return normalized === 'qwen-mt' || normalized.includes('qwen-mt-');
+}
+
+export function resolveOpenAIMessageLayout(
+  layout: OpenAIMessageLayout | string | undefined,
+  modelName?: string,
+): Exclude<OpenAIMessageLayout, 'auto'> {
+  if (layout === 'system_user' || layout === 'single_user') {
+    return layout;
+  }
+  return requiresSingleUserMessage(modelName) ? 'single_user' : 'system_user';
+}
+
+/**
+ * 构造 OpenAI Chat Completions 的消息数组。
+ *
+ * single_user 会把系统提示词与本次用户内容合并为唯一一条 user 消息，
+ * 兼容 Qwen-MT 等不接受 system 消息或多消息输入的翻译专用模型。
+ */
+export function buildOpenAIRequestMessages(
+  systemPrompt: string,
+  userPrompt: string,
+  layout: OpenAIMessageLayout | string | undefined,
+  modelName?: string,
+): OpenAIRequestMessage[] {
+  const resolved = resolveOpenAIMessageLayout(layout, modelName);
+  if (resolved === 'single_user') {
+    return [
+      {
+        role: 'user',
+        content: `${systemPrompt}\n\n${userPrompt}`,
+      },
+    ];
+  }
+
+  return [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userPrompt },
+  ];
+}

--- a/renderer/lib/providerPanelUtils.ts
+++ b/renderer/lib/providerPanelUtils.ts
@@ -7,6 +7,7 @@ export const LAST_PROVIDER_STORAGE_KEY = 'resourcesProvidersSelectedId';
 export const PROVIDER_ADVANCED_FIELD_KEYS = new Set([
   'systemPrompt',
   'prompt',
+  'messageLayout',
   'structuredOutput',
   'windowMaxRequests',
 ]);

--- a/renderer/public/locales/en/translateControl.json
+++ b/renderer/public/locales/en/translateControl.json
@@ -95,6 +95,8 @@
   "model": "Model",
   "structuredOutput": "Structured Output",
   "structuredOutputTips": "Select the structured output type supported by your AI service provider:<br/>• <strong>Disabled</strong> - No structured output, model returns content freely<br/>• <strong>JSON Object</strong> - Standard JSON object format (suitable for DeepSeek, Qwen, etc.)<br/>• <strong>JSON Schema</strong> - Strict JSON schema validation (suitable for OpenAI, Azure OpenAI, Gemini, etc.; locks the translation count at the decoding level — strongly recommended for large batches)<br/><br/>Different AI providers support different structured output types. Selecting the wrong type may cause translation failures.",
+  "messageLayout": "Message Layout",
+  "messageLayoutTips": "Controls the messages sent to an OpenAI-compatible API:<br/>• <strong>Auto</strong> - Qwen-MT models use one user message; other models use system + user<br/>• <strong>System + User</strong> - Standard chat-model layout<br/>• <strong>Single User Message</strong> - Merges the system prompt and user content for translation models that reject system messages or multiple messages",
   "echoAnchoring": "Echo Alignment Check",
   "echoAnchoringTips": "When enabled, the model returns both the source echo and the translation for every subtitle entry. The app uses the echo to detect and repair misalignment caused by merged neighbouring subtitles, keeping translations aligned with the timeline. Roughly doubles output token usage; when disabled, only count and empty-value checks apply.",
   "echoPromptOutdatedHint": "Your custom prompt does not include the src/tr echo protocol. Translation still works, but misalignment detection is unavailable. Consider updating it based on the default prompt, or restoring the default.",
@@ -130,6 +132,9 @@
   "confirmRemoveProvider": "Remove this provider?",
   "removeProviderConfirmDesc": "After removal, the configuration (including the API key) for provider \"{{name}}\" will be deleted and you'll need to add it again.",
   "option": {
+    "auto": "Auto (single user message for Qwen-MT)",
+    "system_user": "System + User",
+    "single_user": "Single User Message",
     "disabled": "Disabled",
     "json_object": "JSON Object",
     "json_schema": "JSON Schema"

--- a/renderer/public/locales/zh/translateControl.json
+++ b/renderer/public/locales/zh/translateControl.json
@@ -97,6 +97,8 @@
   "model": "模型",
   "structuredOutput": "结构化输出",
   "structuredOutputTips": "选择AI服务提供商支持的结构化输出类型：<br/>• <strong>Disabled</strong> - 不使用结构化输出，模型自由返回内容<br/>• <strong>JSON Object</strong> - 使用标准JSON对象格式（适用于DeepSeek、Qwen等）<br/>• <strong>JSON Schema</strong> - 使用严格的JSON模式验证（适用于OpenAI、Azure OpenAI、Gemini等，可在解码层面锁定译文条数，强烈推荐大批量时开启）<br/><br/>不同的AI服务商对结构化输出支持不同，选择错误的类型可能导致翻译失败。",
+  "messageLayout": "消息结构",
+  "messageLayoutTips": "控制发送到 OpenAI 兼容接口的 messages：<br/>• <strong>自动</strong> - Qwen-MT 型号使用单条 user 消息，其他型号使用 system + user<br/>• <strong>系统消息 + 用户消息</strong> - 标准聊天模型格式<br/>• <strong>单条用户消息</strong> - 将系统提示词与用户内容合并，适用于不支持 system 消息或多消息输入的翻译专用模型",
   "echoAnchoring": "回显对齐校验",
   "echoAnchoringTips": "开启后模型会对每条字幕同时返回原文回显与译文，系统据此检测并修复「相邻字幕被合并翻译导致的错位」，确保译文与时间轴逐条对齐。会增加约一倍的输出 token 消耗；关闭后仅校验条数与空值。",
   "echoPromptOutdatedHint": "当前自定义提示词未包含 src/tr 回显协议，翻译仍可进行，但无法享受错位检测保护。建议参考默认提示词更新，或恢复默认值。",
@@ -130,6 +132,9 @@
   "confirmRemoveProvider": "确认删除该服务商？",
   "removeProviderConfirmDesc": "删除后服务商「{{name}}」的配置（含 API Key）将被移除，需要重新添加。",
   "option": {
+    "auto": "自动（Qwen-MT 使用单条用户消息）",
+    "system_user": "系统消息 + 用户消息",
+    "single_user": "单条用户消息",
     "disabled": "不使用",
     "json_object": "JSON Object（标准 JSON 对象）",
     "json_schema": "JSON Schema（严格模式校验）"

--- a/scripts/test-structured-output-fallback.ts
+++ b/scripts/test-structured-output-fallback.ts
@@ -10,6 +10,12 @@ import {
   BATCH_SCHEMA_MAX_PROPERTIES,
   makeBatchSchema,
 } from '../main/translate/constants/schema';
+import {
+  buildOpenAIRequestMessages,
+  requiresSingleUserMessage,
+  resolveOpenAIMessageLayout,
+} from '../main/service/openaiMessageLayout';
+import { CONFIG_TEMPLATES, PROVIDER_TYPES } from '../types/provider';
 
 let passed = 0;
 let failed = 0;
@@ -206,6 +212,84 @@ async function run(): Promise<void> {
       'batch-schema: property cap constant exposed',
     );
   }
+
+  // OpenAI 兼容消息结构：Qwen-MT 自动合并为唯一 user 消息（issue #376）
+  eq(
+    requiresSingleUserMessage('qwen-mt-plus'),
+    true,
+    'message-layout: detects official qwen-mt model id',
+  );
+  eq(
+    requiresSingleUserMessage('Qwen/Qwen-MT-Turbo'),
+    true,
+    'message-layout: detects namespaced qwen-mt model id',
+  );
+  eq(
+    resolveOpenAIMessageLayout(undefined, 'gpt-4o-mini'),
+    'system_user',
+    'message-layout: auto keeps standard models unchanged',
+  );
+  eq(
+    buildOpenAIRequestMessages(
+      'System instructions',
+      '{"1":"Hello"}',
+      'auto',
+      'qwen-mt-plus',
+    ),
+    [
+      {
+        role: 'user',
+        content: 'System instructions\n\n{"1":"Hello"}',
+      },
+    ],
+    'message-layout: auto merges qwen-mt into one user message',
+  );
+  eq(
+    buildOpenAIRequestMessages(
+      'System instructions',
+      'User content',
+      'system_user',
+      'qwen-mt-plus',
+    ),
+    [
+      { role: 'system', content: 'System instructions' },
+      { role: 'user', content: 'User content' },
+    ],
+    'message-layout: explicit system_user overrides qwen-mt auto detection',
+  );
+  eq(
+    buildOpenAIRequestMessages(
+      'System instructions',
+      'User content',
+      'single_user',
+      'gpt-4o-mini',
+    ),
+    [{ role: 'user', content: 'System instructions\n\nUser content' }],
+    'message-layout: explicit single_user supports other constrained APIs',
+  );
+
+  const qwenMessageLayout = PROVIDER_TYPES.find(
+    (provider) => provider.id === 'qwen',
+  )?.fields.find((field) => field.key === 'messageLayout');
+  eq(
+    qwenMessageLayout?.defaultValue,
+    'auto',
+    'message-layout: qwen provider exposes auto default',
+  );
+  eq(
+    CONFIG_TEMPLATES.openai.fields.some(
+      (field) => field.key === 'messageLayout',
+    ),
+    true,
+    'message-layout: custom OpenAI provider exposes configuration',
+  );
+  eq(
+    PROVIDER_TYPES.find((provider) => provider.id === 'ollama')?.fields.some(
+      (field) => field.key === 'messageLayout',
+    ),
+    false,
+    'message-layout: unrelated Ollama transport does not expose setting',
+  );
 
   console.log(
     `\nstructured-output-fallback: ${passed} passed, ${failed} failed`,

--- a/types/provider.ts
+++ b/types/provider.ts
@@ -355,13 +355,29 @@ const FIELD_ENABLE_THINKING: ProviderField = {
   tips: 'enableThinkingTips',
 };
 
+/**
+ * OpenAI 兼容接口的消息结构。
+ * auto 会为 Qwen-MT 合并成单条 user 消息，其余模型保持 system + user。
+ */
+const FIELD_MESSAGE_LAYOUT: ProviderField = {
+  key: 'messageLayout',
+  label: 'messageLayout',
+  type: 'select',
+  required: false,
+  defaultValue: 'auto',
+  options: ['auto', 'system_user', 'single_user'],
+  tips: 'messageLayoutTips',
+};
+
 const aiCommonFields = (overrides?: {
   batchSize?: number;
   batchSizeTips?: string;
   structuredOutput?: string;
+  messageLayout?: boolean;
 }): ProviderField[] => [
   FIELD_SYSTEM_PROMPT,
   FIELD_USER_PROMPT,
+  ...(overrides?.messageLayout === false ? [] : [FIELD_MESSAGE_LAYOUT]),
   structuredOutputField(overrides?.structuredOutput),
   FIELD_ECHO_ANCHORING,
   FIELD_ENABLE_THINKING,
@@ -769,7 +785,11 @@ export const PROVIDER_TYPES: ProviderType[] = [
       },
       // ollama ≥0.5 支持 schema 约束解码，是本地小模型条数对齐的最大收益点；
       // 旧版本由运行时回退链自动降级（openspec: ai-translation-alignment）
-      ...aiCommonFields({ batchSize: 10, structuredOutput: 'json_schema' }),
+      ...aiCommonFields({
+        batchSize: 10,
+        structuredOutput: 'json_schema',
+        messageLayout: false,
+      }),
     ],
   },
   {
@@ -835,7 +855,10 @@ export const PROVIDER_TYPES: ProviderType[] = [
         tips: 'azureOpenAiApiKeyTips',
         placeholder: 'phAzureOpenAiApiKey',
       },
-      ...aiCommonFields({ structuredOutput: 'json_schema' }),
+      ...aiCommonFields({
+        structuredOutput: 'json_schema',
+        messageLayout: false,
+      }),
     ],
   },
   {


### PR DESCRIPTION
## 改动内容

- 为 OpenAI 兼容翻译服务新增“消息结构”配置，支持自动、`system + user` 和单条 `user` 三种模式。
- 自动模式识别 Qwen-MT 型号，并把系统提示词与本次翻译内容合并为唯一一条 `user` 消息；其他模型继续使用原有结构。
- 在通义千问及自定义 OpenAI 兼容服务的高级设置中提供该选项，同时补充中英文说明。
- 增加消息结构解析、Qwen-MT 自动识别、显式覆盖和表单字段范围测试。

## 问题原因

Qwen-MT 的 OpenAI 兼容接口要求 `messages` 中只能有一条 `user` 消息，不支持原有的 `system + user` 结构，因此会在请求阶段直接报错。本次修改保留普通聊天模型的现有行为，并为翻译专用模型提供兼容结构。

## 验证

- `corepack yarn test:structured-output`：32 项通过
- `corepack yarn test:thinking-control`：48 项通过
- `corepack yarn check:i18n`：通过
- OpenAI 主进程入口独立 TypeScript 编译：通过
- Prettier 检查：通过
- `corepack yarn build`：渲染端与类型检查通过；主进程阶段受本机 Node 22 与项目现有 Nextron/Webpack 版本冲突影响失败，CI 使用项目指定的 Node 20 继续验证完整构建

Closes #376
