### PR TITLE
feat(transcription): 增加 faster-whisper 高级解码参数

### DIFF
--- a/main/helpers/engines/fasterWhisperEngine.ts
+++ b/main/helpers/engines/fasterWhisperEngine.ts
@@ -36,6 +36,7 @@ import {
 } from './transcribeShared';
 import { resolveEffectiveSettings } from './outcomePresets';
 import type { TranscribeContext, TranscriptionEngineAdapter } from './types';
+import { buildFasterWhisperAdvancedParams } from '../../../types/transcriptionParams';
 
 /**
  * 判定是否为 CUDA 运行库（cuBLAS/cuDNN/cudart）缺失或无法加载类错误。
@@ -216,6 +217,10 @@ async function transcribeFasterWhisper(
     vad_speech_pad_ms: getNumericSetting(settings.vadSpeechPad, 200),
     // 抗幻觉/抗重复参数（仅开关开启时注入；关闭则不下发，sidecar 回落默认）。
     ...getFasterWhisperAntiRepetitionParams(settings),
+    // 任务级高级解码参数：只下发新版 sidecar 契约支持且通过类型/范围校验的显式值；
+    // 未设置或非法值保持缺键，完整保留 faster-whisper 默认行为。旧 runtime 可能
+    // 忽略新增字段，UI 会明确提示用户先更新。
+    ...buildFasterWhisperAdvancedParams(formData),
   };
 
   const signal = ctx.signal ?? getTaskContext()?.signal;

--- a/renderer/components/tasks/AdvancedSheet.tsx
+++ b/renderer/components/tasks/AdvancedSheet.tsx
@@ -13,6 +13,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
 } from '@/components/ui/form';
 import {
   Select,
@@ -42,6 +43,13 @@ import {
   type SubtitleOutcome,
 } from 'lib/subtitleOutcome';
 import { useTranslation } from 'next-i18next';
+import {
+  FASTER_WHISPER_ADVANCED_PARAM_SPECS,
+  isValidFasterWhisperAdvancedParamValue,
+  supportsFasterWhisperAdvancedParams,
+  type FasterWhisperAdvancedParamSpec,
+  type FasterWhisperAdvancedSettingKey,
+} from '../../../types/transcriptionParams';
 
 interface AdvancedSheetProps {
   open: boolean;
@@ -58,6 +66,204 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
     </h4>
   );
 }
+
+function formatAdvancedNumberDraft(value: unknown): string {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? String(value)
+    : '';
+}
+
+/**
+ * 独立草稿避免数值输入的负号/小数中间态被受控 value 立即改写。
+ * 编辑中即时展示错误但不把非法值写进任务配置；失焦时非法值清空，确保任务永远只拿到
+ * 合法数字或 undefined（undefined = 沿用引擎默认）。
+ */
+const FasterWhisperAdvancedNumberField: React.FC<{
+  form: any;
+  spec: FasterWhisperAdvancedParamSpec;
+  field: any;
+}> = ({ form, spec, field }) => {
+  const { t } = useTranslation('tasks');
+  const [draft, setDraft] = useState(() =>
+    formatAdvancedNumberDraft(field.value),
+  );
+  const [editing, setEditing] = useState(false);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraft(formatAdvancedNumberDraft(field.value));
+    }
+  }, [editing, field.value]);
+
+  const validationMessage = t(
+    spec.integer
+      ? 'fasterWhisperAdvanced.integerRangeError'
+      : 'fasterWhisperAdvanced.rangeError',
+    {
+      min: spec.min,
+      max: spec.max,
+    },
+  );
+
+  const updateFormValue = (raw: string) => {
+    if (raw.trim() === '') {
+      form.setValue(spec.settingKey, undefined, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+      form.clearErrors(spec.settingKey);
+      return;
+    }
+
+    const nextValue = Number(raw);
+    if (isValidFasterWhisperAdvancedParamValue(nextValue, spec)) {
+      form.setValue(spec.settingKey, nextValue, {
+        shouldDirty: true,
+        shouldValidate: true,
+      });
+      form.clearErrors(spec.settingKey);
+      return;
+    }
+
+    // 草稿可暂时非法，但任务配置始终回落 undefined，防止快捷键开跑或持久化脏值。
+    form.setValue(spec.settingKey, undefined, {
+      shouldDirty: true,
+      shouldValidate: false,
+    });
+    form.setError(spec.settingKey, {
+      type: 'validate',
+      message: validationMessage,
+    });
+  };
+
+  return (
+    <FormItem>
+      <FormLabel>
+        {t(`fasterWhisperAdvanced.fields.${spec.runtimeKey}.label`)}
+      </FormLabel>
+      <FormControl>
+        <Input
+          type="text"
+          inputMode={spec.integer ? 'numeric' : 'decimal'}
+          value={draft}
+          placeholder={t(
+            `fasterWhisperAdvanced.fields.${spec.runtimeKey}.placeholder`,
+          )}
+          onFocus={() => setEditing(true)}
+          onChange={(event) => {
+            const raw = event.target.value;
+            setDraft(raw);
+            updateFormValue(raw);
+          }}
+          onBlur={() => {
+            setEditing(false);
+            const parsed = draft.trim() === '' ? undefined : Number(draft);
+            if (
+              parsed === undefined ||
+              !isValidFasterWhisperAdvancedParamValue(parsed, spec)
+            ) {
+              setDraft('');
+              form.setValue(spec.settingKey, undefined, {
+                shouldDirty: true,
+                shouldValidate: true,
+              });
+            } else {
+              setDraft(String(parsed));
+              form.setValue(spec.settingKey, parsed, {
+                shouldDirty: true,
+                shouldValidate: true,
+              });
+            }
+            field.onBlur();
+          }}
+        />
+      </FormControl>
+      <FormDescription className="text-xs">
+        {t(`fasterWhisperAdvanced.fields.${spec.runtimeKey}.hint`)}
+      </FormDescription>
+      <FormMessage />
+    </FormItem>
+  );
+};
+
+const FasterWhisperAdvancedFields: React.FC<{ form: any }> = ({ form }) => {
+  const { t } = useTranslation('tasks');
+
+  return (
+    <Collapsible className="rounded-lg border">
+      <CollapsibleTrigger
+        type="button"
+        className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left"
+      >
+        <span className="space-y-0.5">
+          <span className="flex items-center gap-2 text-sm font-medium">
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            {t('fasterWhisperAdvanced.title')}
+            <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+              faster-whisper
+            </Badge>
+          </span>
+          <span className="block text-xs font-normal text-muted-foreground">
+            {t('fasterWhisperAdvanced.summary')}
+          </span>
+        </span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-4 border-t px-3 py-3">
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {t('fasterWhisperAdvanced.description')}
+        </p>
+        <p className="rounded-md bg-muted/60 px-2.5 py-2 text-xs leading-relaxed text-muted-foreground">
+          {t('fasterWhisperAdvanced.runtimeNote')}
+        </p>
+        {FASTER_WHISPER_ADVANCED_PARAM_SPECS.map((spec) => (
+          <FormField
+            key={spec.settingKey}
+            control={form.control}
+            name={spec.settingKey}
+            rules={{
+              validate: (value) =>
+                value === undefined ||
+                value === '' ||
+                isValidFasterWhisperAdvancedParamValue(value, spec) ||
+                t(
+                  spec.integer
+                    ? 'fasterWhisperAdvanced.integerRangeError'
+                    : 'fasterWhisperAdvanced.rangeError',
+                  {
+                    min: spec.min,
+                    max: spec.max,
+                  },
+                ),
+            }}
+            render={({ field }) => (
+              <FasterWhisperAdvancedNumberField
+                form={form}
+                spec={spec}
+                field={field}
+              />
+            )}
+          />
+        ))}
+        <button
+          type="button"
+          className="text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          onClick={() => {
+            FASTER_WHISPER_ADVANCED_PARAM_SPECS.forEach((spec) => {
+              form.setValue(
+                spec.settingKey as FasterWhisperAdvancedSettingKey,
+                undefined,
+                { shouldDirty: true, shouldValidate: true },
+              );
+            });
+          }}
+        >
+          {t('fasterWhisperAdvanced.reset')}
+        </button>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
 
 type SubtitleLengthMode = 'smart' | 'unlimited' | 'custom';
 
@@ -442,6 +648,10 @@ const AdvancedSheet: React.FC<AdvancedSheetProps> = ({
                           </FormItem>
                         )}
                       />
+
+                      {supportsFasterWhisperAdvancedParams(engine) && (
+                        <FasterWhisperAdvancedFields form={form} />
+                      )}
                       <FormField
                         control={form.control}
                         name="saveAudio"

--- a/renderer/public/locales/en/tasks.json
+++ b/renderer/public/locales/en/tasks.json
@@ -171,6 +171,47 @@
     "off": "Off: engine defaults (keeps cross-segment coherence); long videos or silence may produce repeated or hallucinated lines.",
     "hint": "Turn on when subtitles loop or repeat heavily. Global setting; applies to both faster-whisper and whisper.cpp."
   },
+  "fasterWhisperAdvanced": {
+    "title": "Advanced decoding parameters",
+    "summary": "Optional; leave blank to use engine defaults",
+    "description": "Applies only to the current faster-whisper task. Values are type- and range-checked before dispatch. Blank fields send no overrides and preserve the engine's default strategy.",
+    "runtimeNote": "Requires the latest faster-whisper runtime with advanced-parameter forwarding. Older runtimes may ignore some settings; check for updates in Resources → Engines.",
+    "rangeError": "Enter a number between {{min}} and {{max}}",
+    "integerRangeError": "Enter a whole number between {{min}} and {{max}}",
+    "reset": "Reset all to engine defaults",
+    "fields": {
+      "beam_size": {
+        "label": "Beam size",
+        "placeholder": "Engine default: 5",
+        "hint": "Whole number from 1–20. Higher values can improve decoding stability at the cost of more computation and time."
+      },
+      "best_of": {
+        "label": "Best of",
+        "placeholder": "Engine default: 5",
+        "hint": "Whole number from 1–20. Keeps more candidates when sampling above zero temperature; higher values cost more computation."
+      },
+      "temperature": {
+        "label": "Sampling temperature",
+        "placeholder": "Engine default: adaptive 0.0 → 1.0 fallback",
+        "hint": "Range 0–1. Higher is more random; a single value replaces the engine's default multi-temperature fallback sequence."
+      },
+      "compression_ratio_threshold": {
+        "label": "Compression ratio threshold",
+        "placeholder": "Engine default: 2.4",
+        "hint": "Range 0–10. Decoding falls back when text compression exceeds this value; low values may cause more retries."
+      },
+      "log_prob_threshold": {
+        "label": "Average log-probability threshold",
+        "placeholder": "Engine default: -1.0",
+        "hint": "Range -5–0. Decoding falls back when the average log probability is below this value."
+      },
+      "no_speech_threshold": {
+        "label": "No-speech threshold",
+        "placeholder": "Engine default: 0.6",
+        "hint": "Range 0–1. Works with the log-probability threshold to skip no-speech segments; lower values skip more readily."
+      }
+    }
+  },
   "subtitleLength": {
     "label": "Subtitle line breaking",
     "modeSmart": "Smart segmentation (recommended)",

--- a/renderer/public/locales/zh/tasks.json
+++ b/renderer/public/locales/zh/tasks.json
@@ -171,6 +171,47 @@
     "off": "已关闭：使用引擎默认（保留上文连贯性）；长视频或静音处可能出现重复或幻觉字幕。",
     "hint": "遇到字幕大段重复/鬼畜时开启。全局设置，对 faster-whisper 与 whisper.cpp 同时生效。"
   },
+  "fasterWhisperAdvanced": {
+    "title": "高级解码参数",
+    "summary": "可选；留空使用引擎默认值",
+    "description": "仅对当前 faster-whisper 任务生效。参数会先经过类型和范围校验；留空不会下发任何覆盖值，仍使用引擎默认策略。",
+    "runtimeNote": "需要使用包含高级参数透传支持的最新版 faster-whisper runtime；较旧 runtime 可能忽略部分设置。可在资源中心 → 引擎检查并更新。",
+    "rangeError": "请输入 {{min}} 到 {{max}} 之间的数字",
+    "integerRangeError": "请输入 {{min}} 到 {{max}} 之间的整数",
+    "reset": "全部恢复为引擎默认值",
+    "fields": {
+      "beam_size": {
+        "label": "束搜索宽度（Beam size）",
+        "placeholder": "引擎默认：5",
+        "hint": "范围 1–20 的整数。值越大通常识别更稳，但会增加计算量和耗时。"
+      },
+      "best_of": {
+        "label": "候选采样数（Best of）",
+        "placeholder": "引擎默认：5",
+        "hint": "范围 1–20 的整数。在非零温度采样时保留更多候选，值越大计算量越高。"
+      },
+      "temperature": {
+        "label": "采样温度",
+        "placeholder": "引擎默认：0.0 → 1.0 自适应回退",
+        "hint": "范围 0–1。越高越随机；设置单个值会替代引擎默认的多温度回退序列。"
+      },
+      "compression_ratio_threshold": {
+        "label": "压缩比阈值",
+        "placeholder": "引擎默认：2.4",
+        "hint": "范围 0–10。文本压缩比超过该值时会触发解码回退；过低可能增加重试。"
+      },
+      "log_prob_threshold": {
+        "label": "平均对数概率阈值",
+        "placeholder": "引擎默认：-1.0",
+        "hint": "范围 -5–0。平均对数概率低于该值时会触发解码回退。"
+      },
+      "no_speech_threshold": {
+        "label": "无语音阈值",
+        "placeholder": "引擎默认：0.6",
+        "hint": "范围 0–1。与对数概率阈值共同判断是否跳过无语音片段；越低越容易跳过。"
+      }
+    }
+  },
   "subtitleLength": {
     "label": "字幕断句方式",
     "modeSmart": "智能断句（推荐）",

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -17,6 +17,12 @@ import {
   secondsToSrtTime,
   getVadSettings,
 } from '../main/helpers/engines/transcribeShared';
+import {
+  buildFasterWhisperAdvancedParams,
+  FASTER_WHISPER_ADVANCED_PARAM_SPECS,
+  isValidFasterWhisperAdvancedParamValue,
+  supportsFasterWhisperAdvancedParams,
+} from '../types/transcriptionParams';
 import { toFasterWhisperModel } from '../main/helpers/engines/modelMap';
 import {
   isProtocolSupported,
@@ -303,6 +309,119 @@ eq(
   getVadSettings({ vadThreshold: 0.8 }).vadThreshold,
   0.8,
   'vad: custom threshold passthrough',
+);
+
+// --- faster-whisper advanced transcription params ---
+eq(
+  buildFasterWhisperAdvancedParams({}),
+  {},
+  'faster advanced: unset preserves engine defaults',
+);
+eq(
+  buildFasterWhisperAdvancedParams({
+    fasterWhisperBeamSize: 6,
+    fasterWhisperBestOf: 4,
+    fasterWhisperTemperature: 0.4,
+    fasterWhisperCompressionRatioThreshold: 2.8,
+    fasterWhisperLogProbThreshold: -0.8,
+    fasterWhisperNoSpeechThreshold: 0.7,
+  }),
+  {
+    beam_size: 6,
+    best_of: 4,
+    temperature: 0.4,
+    compression_ratio_threshold: 2.8,
+    log_prob_threshold: -0.8,
+    no_speech_threshold: 0.7,
+  },
+  'faster advanced: valid task values map to sidecar keys',
+);
+eq(
+  buildFasterWhisperAdvancedParams({
+    fasterWhisperBeamSize: 1,
+    fasterWhisperBestOf: 20,
+    fasterWhisperTemperature: 0,
+    fasterWhisperCompressionRatioThreshold: 10,
+    fasterWhisperLogProbThreshold: -5,
+    fasterWhisperNoSpeechThreshold: 1,
+  }),
+  {
+    beam_size: 1,
+    best_of: 20,
+    temperature: 0,
+    compression_ratio_threshold: 10,
+    log_prob_threshold: -5,
+    no_speech_threshold: 1,
+  },
+  'faster advanced: inclusive range boundaries are accepted',
+);
+eq(
+  buildFasterWhisperAdvancedParams({
+    fasterWhisperBeamSize: 0,
+    fasterWhisperBestOf: 21,
+    fasterWhisperTemperature: 1.1,
+    fasterWhisperCompressionRatioThreshold: -0.1,
+    fasterWhisperLogProbThreshold: 0.1,
+    fasterWhisperNoSpeechThreshold: NaN,
+  }),
+  {},
+  'faster advanced: non-finite and out-of-range values are ignored',
+);
+eq(
+  buildFasterWhisperAdvancedParams({
+    fasterWhisperBeamSize: 1.5,
+    fasterWhisperBestOf: 2.2,
+    fasterWhisperTemperature: 0.5,
+  }),
+  { temperature: 0.5 },
+  'faster advanced: fractional integer parameters are rejected',
+);
+eq(
+  buildFasterWhisperAdvancedParams({
+    fasterWhisperTemperature: '0.4',
+    fasterWhisperCompressionRatioThreshold: null,
+  }),
+  {},
+  'faster advanced: non-number values are ignored',
+);
+eq(
+  FASTER_WHISPER_ADVANCED_PARAM_SPECS.map((spec) => spec.engineDefault),
+  [5, 5, [0, 0.2, 0.4, 0.6, 0.8, 1], 2.4, -1, 0.6],
+  'faster advanced: documented defaults match faster-whisper',
+);
+eq(
+  isValidFasterWhisperAdvancedParamValue(
+    5,
+    FASTER_WHISPER_ADVANCED_PARAM_SPECS[0],
+  ),
+  true,
+  'faster advanced: integer validator accepts whole numbers',
+);
+eq(
+  isValidFasterWhisperAdvancedParamValue(
+    5.5,
+    FASTER_WHISPER_ADVANCED_PARAM_SPECS[0],
+  ),
+  false,
+  'faster advanced: integer validator rejects fractions',
+);
+eq(
+  supportsFasterWhisperAdvancedParams('fasterWhisper'),
+  true,
+  'faster advanced: faster-whisper capability enabled',
+);
+eq(
+  [
+    'builtin',
+    'localCli',
+    'funasr',
+    'qwen',
+    'fireRedAsr',
+    'cloud',
+    undefined,
+  ].some(supportsFasterWhisperAdvancedParams),
+  false,
+  'faster advanced: unsupported engines do not expose controls',
 );
 
 // --- toFasterWhisperModel ---

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,3 +4,4 @@ export * from './parameterSystem';
 export * from './proofread';
 export * from './addon';
 export * from './workItem';
+export * from './transcriptionParams';

--- a/types/transcriptionParams.ts
+++ b/types/transcriptionParams.ts
@@ -1,0 +1,113 @@
+/**
+ * faster-whisper sidecar 支持透传的任务级高级参数。
+ *
+ * 未设置（undefined）时不向 sidecar 下发字段，让 faster-whisper 使用自身默认值；
+ * 非数字、非有限值、超出保守范围或整数参数传小数时同样忽略，避免导入/历史配置
+ * 绕过 UI 校验。beam_size / best_of 需要包含对应白名单的新版 runtime。
+ */
+export const FASTER_WHISPER_ADVANCED_PARAM_SPECS = [
+  {
+    settingKey: 'fasterWhisperBeamSize',
+    runtimeKey: 'beam_size',
+    min: 1,
+    max: 20,
+    step: 1,
+    integer: true,
+    engineDefault: 5,
+  },
+  {
+    settingKey: 'fasterWhisperBestOf',
+    runtimeKey: 'best_of',
+    min: 1,
+    max: 20,
+    step: 1,
+    integer: true,
+    engineDefault: 5,
+  },
+  {
+    settingKey: 'fasterWhisperTemperature',
+    runtimeKey: 'temperature',
+    min: 0,
+    max: 1,
+    step: 0.1,
+    integer: false,
+    engineDefault: [0, 0.2, 0.4, 0.6, 0.8, 1] as const,
+  },
+  {
+    settingKey: 'fasterWhisperCompressionRatioThreshold',
+    runtimeKey: 'compression_ratio_threshold',
+    min: 0,
+    max: 10,
+    step: 0.1,
+    integer: false,
+    engineDefault: 2.4,
+  },
+  {
+    settingKey: 'fasterWhisperLogProbThreshold',
+    runtimeKey: 'log_prob_threshold',
+    min: -5,
+    max: 0,
+    step: 0.1,
+    integer: false,
+    engineDefault: -1,
+  },
+  {
+    settingKey: 'fasterWhisperNoSpeechThreshold',
+    runtimeKey: 'no_speech_threshold',
+    min: 0,
+    max: 1,
+    step: 0.1,
+    integer: false,
+    engineDefault: 0.6,
+  },
+] as const;
+
+export type FasterWhisperAdvancedParamSpec =
+  (typeof FASTER_WHISPER_ADVANCED_PARAM_SPECS)[number];
+
+export type FasterWhisperAdvancedSettingKey =
+  (typeof FASTER_WHISPER_ADVANCED_PARAM_SPECS)[number]['settingKey'];
+
+export type FasterWhisperAdvancedRuntimeKey =
+  (typeof FASTER_WHISPER_ADVANCED_PARAM_SPECS)[number]['runtimeKey'];
+
+export type FasterWhisperAdvancedParams = Partial<
+  Record<FasterWhisperAdvancedRuntimeKey, number>
+>;
+
+/** 高级解码字段只对 faster-whisper 有效；其它引擎不展示、也不消费。 */
+export function supportsFasterWhisperAdvancedParams(
+  engine: unknown,
+): engine is 'fasterWhisper' {
+  return engine === 'fasterWhisper';
+}
+
+export function isValidFasterWhisperAdvancedParamValue(
+  value: unknown,
+  spec: Pick<FasterWhisperAdvancedParamSpec, 'min' | 'max' | 'integer'>,
+): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    value >= spec.min &&
+    value <= spec.max &&
+    (!spec.integer || Number.isInteger(value))
+  );
+}
+
+/**
+ * 把任务表单中的命名空间字段映射为 sidecar 参数。
+ * 返回值只含经过类型与范围校验的显式设置；空对象即完全沿用引擎默认行为。
+ */
+export function buildFasterWhisperAdvancedParams(
+  config: Record<string, unknown> | undefined,
+): FasterWhisperAdvancedParams {
+  const params: Record<string, number> = {};
+  for (const spec of FASTER_WHISPER_ADVANCED_PARAM_SPECS) {
+    const value = config?.[spec.settingKey];
+    if (isValidFasterWhisperAdvancedParamValue(value, spec)) {
+      params[spec.runtimeKey] = value;
+    }
+  }
+  return params as FasterWhisperAdvancedParams;
+}

--- a/types/types.ts
+++ b/types/types.ts
@@ -199,6 +199,16 @@ export interface IFormData {
    * 正数 = 自定义上限（超出时在标点或词边界处拆分）。
    */
   maxSubtitleChars?: number;
+  /**
+   * faster-whisper 解码高级参数（均为任务级、可选）。
+   * 缺省时不下发，让引擎保留自身默认与 temperature 回退序列。
+   */
+  fasterWhisperBeamSize?: number;
+  fasterWhisperBestOf?: number;
+  fasterWhisperTemperature?: number;
+  fasterWhisperCompressionRatioThreshold?: number;
+  fasterWhisperLogProbThreshold?: number;
+  fasterWhisperNoSpeechThreshold?: number;
   /** 中文标点去除（任务级开关）：开启后把中文标点替换为空格。作用于源字幕(中文源)与译文(中文目标)。缺省关闭。 */
   removeChinesePunctuation?: boolean;
 }


### PR DESCRIPTION
## 变更内容

- 在任务高级设置中为 faster-whisper 增加 6 个可选解码参数：
  - `beam_size`（整数 1–20）
  - `best_of`（整数 1–20）
  - `temperature`（0–1）
  - `compression_ratio_threshold`（0–10）
  - `log_prob_threshold`（-5–0）
  - `no_speech_threshold`（0–1）
- 所有字段留空时不下发覆盖值，完整保留 faster-whisper 默认策略和温度回退序列
- UI 使用独立文本草稿支持负数/小数输入中间态；非法值即时提示、不会写入任务配置，失焦后清空
- 主进程按同一共享 spec 再做有限数字、范围和整数校验，阻止导入配置或历史脏值绕过 UI
- 控件只在 faster-whisper 引擎显示；其它引擎不会展示或消费这些字段
- 中英文文案明确提示更新 faster-whisper runtime，旧版本可能忽略部分设置

## Runtime 依赖

- 配套 PR：buxuku/smartsub-py-engine#1
- 当前 rolling runtime 0.4.0 已支持原四个阈值；`beam_size` / `best_of` 需要配套 PR 发布的 runtime 0.5.0
- 建议先合并并发布 runtime PR，再合并本 PR

## 未暴露的参数

- `max_len` / `split_on_word` 会与 SmartSub 强制的 token 时间轴和后续断句链冲突
- `suppress_nst` 与 `n_threads` 当前 runtime/addon 契约不支持

因此本 PR 只提供当前链路能真实生效、且不会破坏字幕时间轴的参数，避免“界面可填但运行时无效果”。

## 验证

- `npm run test:engines`：726/726
- `npm run check:i18n`
- 定向 TypeScript、Prettier、`git diff --check`
- Next production build 通过
- 五分支顺序集成后的完整 Renderer + Main build 通过

Closes #294