### PR TITLE
feat(qwen): 支持 Qwen3-ASR 1.7B

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ brew upgrade --cask smartsub # 升级
 | **whisper.cpp（内置）**  | 默认引擎，支持 ggml 量化模型与 GPU 加速                            | 随应用内置，开箱即用               |
 | **faster-whisper**       | 基于 CTranslate2，速度更快，模型按需从 HuggingFace 下载            | 自包含 Python 运行时（应用内下载） |
 | **FunASR**               | SenseVoice（中 / 英 / 日 / 韩 / 粤）与 Paraformer-zh，中文表现优秀 | 内置 sherpa-onnx 原生库            |
-| **Qwen3-ASR**            | 通义千问语音识别（qwen3-asr-0.6b）                                 | 内置 sherpa-onnx 原生库            |
+| **Qwen3-ASR**            | 通义千问语音识别（qwen3-asr-0.6b / 1.7b）                          | 内置 sherpa-onnx 原生库            |
 | **FireRedASR**           | FireRedASR-AED large（中英），中文表现优秀                         | 内置 sherpa-onnx 原生库            |
 | **本地 Whisper CLI**     | 调用你自行安装的 whisper 兼容命令                                  | 使用系统已装命令                   |
 | **云端听写（在线 ASR）** | 8 家在线服务商，免 GPU、支持多服务商多实例                         | 在线服务（音频上传到你配置的端点） |

--- a/README_EN.md
+++ b/README_EN.md
@@ -158,7 +158,7 @@ The engine is a per-task choice. Manage runtimes and models from the "Engines & 
 | **whisper.cpp (built-in)** | Default engine; ggml quantized models and GPU acceleration           | Bundled, works out of the box                    |
 | **faster-whisper**         | CTranslate2-based, faster; models fetched on demand from HuggingFace | Self-contained Python runtime (in-app download)  |
 | **FunASR**                 | SenseVoice (zh/en/ja/ko/yue) and Paraformer-zh; great for Chinese    | Bundled sherpa-onnx native library               |
-| **Qwen3-ASR**              | Qwen speech recognition (qwen3-asr-0.6b)                             | Bundled sherpa-onnx native library               |
+| **Qwen3-ASR**              | Qwen speech recognition (qwen3-asr-0.6b / 1.7b)                      | Bundled sherpa-onnx native library               |
 | **FireRedASR**             | FireRedASR-AED large (zh-en); great for Chinese                      | Bundled sherpa-onnx native library               |
 | **Local Whisper CLI**      | Calls a whisper-compatible command you installed yourself            | Uses your system command                         |
 | **Cloud ASR (online)**     | 8 providers, no GPU needed, multi-provider and multi-instance        | Online service (audio uploaded to your endpoint) |

--- a/README_JA.md
+++ b/README_JA.md
@@ -158,7 +158,7 @@ brew upgrade --cask smartsub # アップグレード
 | **whisper.cpp（内蔵）**  | デフォルトエンジン。ggml 量子化モデルと GPU アクセラレーションに対応        | アプリ内蔵、すぐに利用可能                               |
 | **faster-whisper**       | CTranslate2 ベースで高速。モデルは HuggingFace から必要に応じてダウンロード | 自己完結型 Python ランタイム（アプリ内でダウンロード）   |
 | **FunASR**               | SenseVoice（中/英/日/韓/粤）と Paraformer-zh。中国語に強い                  | 内蔵 sherpa-onnx ネイティブライブラリ                    |
-| **Qwen3-ASR**            | 通義千問の音声認識（qwen3-asr-0.6b）                                        | 内蔵 sherpa-onnx ネイティブライブラリ                    |
+| **Qwen3-ASR**            | 通義千問の音声認識（qwen3-asr-0.6b / 1.7b）                                 | 内蔵 sherpa-onnx ネイティブライブラリ                    |
 | **FireRedASR**           | FireRedASR-AED large（中英）。中国語に強い                                  | 内蔵 sherpa-onnx ネイティブライブラリ                    |
 | **ローカル Whisper CLI** | 自分でインストールした whisper 互換コマンドを呼び出し                       | システムにインストール済みのコマンドを使用               |
 | **クラウド文字起こし**   | 8 社のオンラインサービス。GPU 不要、複数プロバイダー・複数インスタンス対応  | オンラインサービス（設定したエンドポイントへ音声を送信） |

--- a/docs/docs/features/subtitle-generation.md
+++ b/docs/docs/features/subtitle-generation.md
@@ -31,7 +31,7 @@ keywords:
 | **whisper.cpp（内置）** | 默认引擎，ggml 量化模型 + GPU 加速，低配电脑也能流畅跑             | 随应用内置，开箱即用             |
 | **faster-whisper**      | 基于 CTranslate2，速度更快、精度更高                               | 自包含运行时（应用内下载）       |
 | **FunASR**              | SenseVoice（中 / 英 / 日 / 韩 / 粤）与 Paraformer-zh，中文表现优秀 | 内置 sherpa-onnx，无需额外环境   |
-| **Qwen3-ASR**           | 通义千问语音识别（qwen3-asr-0.6b）                                 | 内置 sherpa-onnx，无需额外环境   |
+| **Qwen3-ASR**           | 通义千问语音识别（qwen3-asr-0.6b / 1.7b）                          | 内置 sherpa-onnx，无需额外环境   |
 | **FireRedASR**          | FireRedASR-AED large（中英），中文表现优秀                         | 内置 sherpa-onnx，无需额外环境   |
 | **本地 Whisper CLI**    | 调用你自行安装的 whisper 兼容命令                                  | 使用系统已装命令                 |
 | **云端听写**            | 8 家在线服务商，免 GPU 免模型，部分有免费额度                      | 在线服务（音频上传到配置的端点） |

--- a/docs/docs/guides/engines/qwen3-asr.md
+++ b/docs/docs/guides/engines/qwen3-asr.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 title: Qwen3-ASR
-description: 妙幕 Qwen3-ASR 引擎配置指南：通义千问开源语音识别模型（qwen3-asr-0.6b），内置 sherpa-onnx 原生库离线运行，中文识别表现优秀。
+description: 妙幕 Qwen3-ASR 引擎配置指南：支持 qwen3-asr-0.6b 与 1.7b，使用内置 sherpa-onnx 原生库离线运行。
 keywords: [Qwen3-ASR, 通义千问语音识别, 中文转写, 开源 ASR]
 ---
 
@@ -13,17 +13,17 @@ keywords: [Qwen3-ASR, 通义千问语音识别, 中文转写, 开源 ASR]
   credentials="无需凭据"
   freeTier="完全免费"
   pricing="本地运行，无费用"
-  bestFor="中文内容的轻量本地转写"
+  bestFor="多语种内容的本地高质量转写"
   offline
 />
 
-通义千问开源的语音识别模型（集成 `qwen3-asr-0.6b`），与 FunASR、FireRedASR 一样通过内置 sherpa-onnx 原生库运行，无需额外环境。
+通义千问开源的语音识别模型，支持 `qwen3-asr-0.6b` 与 `qwen3-asr-1.7b`。与 FunASR、FireRedASR 一样通过内置 sherpa-onnx 原生库运行，无需额外环境。
 
 ## 在妙幕中配置
 
 1. 「引擎」页面选中「本地多模型引擎」分组，找到 Qwen3-ASR
-2. 点「下载」获取模型（支持多下载源）
-3. 任务向导「语音模型」中选择即可使用
+2. 按精度和资源需求选择 0.6B 或 1.7B，点「下载」获取模型
+3. 任务向导「语音模型」中选择对应模型即可使用
 
 <div className="img-container">
   <img src="/img/v3/engines/local-multi.webp" alt="本地多模型引擎页面：Qwen3-ASR 模型下载入口" />
@@ -31,13 +31,15 @@ keywords: [Qwen3-ASR, 通义千问语音识别, 中文转写, 开源 ASR]
 
 ## 特点与适用
 
-- 0.6B 参数量，**体积小、加载快**，CPU 即可运行
-- 中文识别表现优秀，适合日常中文内容快速转写
+- 0.6B int8 约 0.95GB，**体积小、加载快**，适合 CPU 日常转写
+- 1.7B int8 约 2.4GB，精度更高，但需要更多内存且 CPU 推理更慢
+- 1.7B 当前通过 ModelScope 逐文件下载；0.6B 还可使用 GitHub 整包源
 - 与 FunASR / FireRedASR 同分组管理，可下载多个模型按任务对比效果
 
 ## 常见问题
 
-- **与 FunASR / FireRedASR 怎么选**：三者都是中文强项——追求多语种选 FunASR（SenseVoice），追求中文精度选 FireRedASR，追求轻量选 Qwen3-ASR；都免费，建议实测各自跑一段素材对比
+- **0.6B 和 1.7B 怎么选**：资源有限或更看重速度时选 0.6B；更看重识别质量且能接受更高内存和耗时时选 1.7B
+- **与 FunASR / FireRedASR 怎么选**：三者都可本地免费使用，语言覆盖和素材表现各有差异，建议用同一段素材实测对比
 - **时间轴粒度**：无词级时间戳，长句拆分按文本比例兜底
 
 ---

--- a/main/helpers/download/fetchJson.ts
+++ b/main/helpers/download/fetchJson.ts
@@ -1,0 +1,107 @@
+import * as http from 'http';
+import * as https from 'https';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_REDIRECTS = 5;
+
+export interface FetchJsonOptions {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+  timeoutMs?: number;
+  maxRedirects?: number;
+  cancelMessage?: string;
+}
+
+/**
+ * 获取 JSON，支持有限重定向、连接超时与 AbortSignal。
+ * 每次重定向继续沿用同一个 signal，避免取消窗口落在重定向/文件树请求期间时失效。
+ */
+export function fetchJson<T>(
+  url: string,
+  options: FetchJsonOptions = {},
+  redirects = 0,
+): Promise<T> {
+  const {
+    signal,
+    headers = {},
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxRedirects = DEFAULT_MAX_REDIRECTS,
+    cancelMessage = 'Download cancelled',
+  } = options;
+
+  if (signal?.aborted) {
+    return Promise.reject(new Error(cancelMessage));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const parsed = new URL(url);
+    const protocol = parsed.protocol === 'https:' ? https : http;
+    let settled = false;
+    let request: http.ClientRequest;
+
+    const cleanup = () => signal?.removeEventListener('abort', onAbort);
+    const succeed = (value: T) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(value);
+    };
+    const fail = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+    const onAbort = () => {
+      const error = new Error(cancelMessage);
+      request.destroy(error);
+      fail(error);
+    };
+
+    request = protocol.get(url, { headers }, (response) => {
+      const status = response.statusCode || 0;
+      if (status >= 300 && status < 400 && response.headers.location) {
+        response.resume();
+        if (redirects >= maxRedirects) {
+          fail(new Error('Too many redirects while fetching JSON'));
+          return;
+        }
+        settled = true;
+        cleanup();
+        fetchJson<T>(
+          new URL(response.headers.location, url).href,
+          options,
+          redirects + 1,
+        ).then(resolve, reject);
+        return;
+      }
+      if (status < 200 || status >= 300) {
+        response.resume();
+        fail(new Error(`HTTP Error: ${status}`));
+        return;
+      }
+
+      const chunks: Buffer[] = [];
+      response.on('data', (chunk: Buffer) => chunks.push(chunk));
+      response.on('aborted', () =>
+        fail(new Error('JSON response aborted before completion')),
+      );
+      response.on('error', fail);
+      response.on('end', () => {
+        if (settled) return;
+        try {
+          succeed(JSON.parse(Buffer.concat(chunks).toString('utf8')) as T);
+        } catch (error) {
+          fail(error);
+        }
+      });
+    });
+
+    request.on('error', fail);
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error('JSON request timeout'));
+    });
+    signal?.addEventListener('abort', onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+}

--- a/main/helpers/engines/qwenEngine.ts
+++ b/main/helpers/engines/qwenEngine.ts
@@ -153,7 +153,7 @@ async function transcribeQwen(ctx: TranscribeContext): Promise<string> {
 
 export const qwenEngineAdapter: TranscriptionEngineAdapter = {
   id: 'qwen',
-  displayName: 'Qwen3-ASR (0.6B)',
+  displayName: 'Qwen3-ASR',
   requiresRuntime: true,
 
   async isAvailable(): Promise<EngineStatus> {

--- a/main/helpers/engines/qwenParams.ts
+++ b/main/helpers/engines/qwenParams.ts
@@ -7,7 +7,7 @@ import { getNumericSetting } from './transcribeShared';
  *   max_total_len=512, max_new_tokens=128, temperature=1e-6, top_p=0.8, seed=42。
  * 注意：Node 绑定对该 config 先 memset(0) 再覆盖存在的键，故每个字段都必须显式给值。
  *
- * 当前范围（P2）：仅 0.6B / CPU / 段级时间戳。语言由 Qwen 内部 prompt 处理，
+ * 当前范围：0.6B / 1.7B、CPU、段级时间戳。语言由 Qwen 内部 prompt 处理，
  * sherpa 的 qwen3Asr 配置不暴露 language 字段，故此处不接收/不映射 sourceLanguage。
  */
 

--- a/main/helpers/modelImport.ts
+++ b/main/helpers/modelImport.ts
@@ -23,17 +23,49 @@ export interface LayoutCheckResult {
   missing: string[];
 }
 
+export interface ModelFileSizeExpectation {
+  path: string;
+  size: number;
+}
+
 /**
  * 校验源目录是否含某模型的全部必需文件。
- * requiredFiles 支持嵌套相对路径（如 `tokenizer/vocab.json`），逐项检查存在性。
+ * requiredFiles 支持嵌套相对路径（如 `tokenizer/vocab.json`）；目录、空文件与
+ * 无法 stat 的路径都视为无效，避免把占位文件误报为可加载模型。
  */
 export function validateModelLayout(
   srcDir: string,
-  requiredFiles: string[],
+  requiredFiles: readonly string[],
 ): LayoutCheckResult {
-  const missing = requiredFiles.filter(
-    (rel) => !fs.existsSync(path.join(srcDir, rel)),
-  );
+  const missing = requiredFiles.filter((rel) => {
+    try {
+      const stat = fs.statSync(path.join(srcDir, rel));
+      return !stat.isFile() || stat.size <= 0;
+    } catch {
+      return true;
+    }
+  });
+  return { ok: missing.length === 0, missing };
+}
+
+/**
+ * 在通用非空文件校验之上要求精确字节数。
+ * 适用于同名布局对应多个模型规格的场景，防止较小模型被导入到较大模型槽位。
+ */
+export function validateModelLayoutWithSizes(
+  srcDir: string,
+  expectedFiles: readonly ModelFileSizeExpectation[],
+): LayoutCheckResult {
+  const missing = expectedFiles
+    .filter(({ path: rel, size }) => {
+      try {
+        const stat = fs.statSync(path.join(srcDir, rel));
+        return !stat.isFile() || stat.size !== size;
+      } catch {
+        return true;
+      }
+    })
+    .map(({ path: rel }) => rel);
   return { ok: missing.length === 0, missing };
 }
 

--- a/main/helpers/qwenModelCatalog.ts
+++ b/main/helpers/qwenModelCatalog.ts
@@ -21,10 +21,10 @@ export function getQwenModelsRoot(): string {
   return root;
 }
 
-/** qwen 子模型标识（与本地子目录一一对应）。P2 仅 0.6B。 */
-export type QwenModelId = 'qwen3-asr-0.6b';
+/** qwen 子模型标识（与本地子目录一一对应）。 */
+export type QwenModelId = 'qwen3-asr-0.6b' | 'qwen3-asr-1.7b';
 
-/** 默认（当前唯一）qwen 模型。 */
+/** 默认 qwen 模型：保留体积更小、CPU 更友好的 0.6B，兼容历史选择。 */
 export const QWEN_DEFAULT_MODEL_ID: QwenModelId = 'qwen3-asr-0.6b';
 
 /**
@@ -45,11 +45,23 @@ const QWEN_SOURCE_ORDER: QwenModelSource[] = [
   'github',
 ];
 
-/** 所选源排第一，其余按规范顺序补齐，供下载失败时自动回退。 */
+/**
+ * 所选源排第一，其余按规范顺序补齐，供下载失败时自动回退。
+ * supported 可限制到模型实际具备的源（1.7B 当前仅有 ModelScope 逐文件资产）。
+ */
 export function getQwenSourceOrder(
   selected: QwenModelSource,
+  supported: readonly QwenModelSource[] = QWEN_SOURCE_ORDER,
 ): QwenModelSource[] {
-  return [selected, ...QWEN_SOURCE_ORDER.filter((s) => s !== selected)];
+  const supportedSet = new Set(supported);
+  const ordered = [
+    selected,
+    ...QWEN_SOURCE_ORDER.filter((s) => s !== selected),
+  ];
+  return ordered.filter(
+    (source, index) =>
+      supportedSet.has(source) && ordered.indexOf(source) === index,
+  );
 }
 
 /** ModelScope 逐文件映射：remote=仓库内路径，local=相对模型目录的落地路径。 */
@@ -67,18 +79,21 @@ export interface QwenModelScopeFile {
 export interface QwenModelSpec {
   id: QwenModelId;
   dirName: string;
-  /** 体积/硬件提示用（解包后约 0.95GB；tar.bz2 下载包约 838MB）。 */
+  /** 体积/硬件提示用（模型安装后的近似字节数）。 */
   approxInstallBytes: number;
   /** ModelScope 仓库 id（逐文件国内源）。 */
   modelScopeRepo: string;
   /** ModelScope 逐文件清单（remote→local）。 */
   modelScopeFiles: QwenModelScopeFile[];
-  /** GitHub release 路径（owner/repo/releases/download/tag），用于整包源拼 URL。 */
-  releasePath: string;
-  /** release 整包文件名（tar.bz2）。 */
-  archiveName: string;
-  /** 解包后顶层目录名（用 decompress strip:1 去掉，此处仅作记录）。 */
-  archiveInnerDir: string;
+  /**
+   * GitHub release 路径（owner/repo/releases/download/tag），用于整包源拼 URL。
+   * 省略表示 sherpa-onnx 尚未发布该规格的 release 整包，只能走 ModelScope。
+   */
+  releasePath?: string;
+  /** release 整包文件名（tar.bz2）；与 releasePath 同时存在。 */
+  archiveName?: string;
+  /** 解包后顶层目录名（用 strip:1 去掉，此处仅作记录）。 */
+  archiveInnerDir?: string;
   /** 判定「已安装」必须存在的关键文件（相对 dirName）。 */
   requiredFiles: string[];
 }
@@ -128,13 +143,57 @@ export const QWEN_MODELS: Record<QwenModelId, QwenModelSpec> = {
       'tokenizer/merges.txt',
     ],
   },
+  'qwen3-asr-1.7b': {
+    id: 'qwen3-asr-1.7b',
+    dirName: 'qwen3-asr-1.7b',
+    // ModelScope int8 三件套 + tokenizer 实际合计约 2.40 GB（十进制）。
+    approxInstallBytes: 2_405_000_000,
+    modelScopeRepo: QWEN_MS_REPO,
+    modelScopeFiles: [
+      { remote: 'model_1.7B/conv_frontend.onnx', local: 'conv_frontend.onnx' },
+      { remote: 'model_1.7B/encoder.int8.onnx', local: 'encoder.int8.onnx' },
+      { remote: 'model_1.7B/decoder.int8.onnx', local: 'decoder.int8.onnx' },
+      { remote: 'tokenizer/vocab.json', local: 'tokenizer/vocab.json' },
+      { remote: 'tokenizer/merges.txt', local: 'tokenizer/merges.txt' },
+      {
+        remote: 'tokenizer/tokenizer_config.json',
+        local: 'tokenizer/tokenizer_config.json',
+      },
+      { remote: 'tokenizer/config.json', local: 'tokenizer/config.json' },
+      {
+        remote: 'tokenizer/chat_template.json',
+        local: 'tokenizer/chat_template.json',
+      },
+      {
+        remote: 'tokenizer/preprocessor_config.json',
+        local: 'tokenizer/preprocessor_config.json',
+      },
+    ],
+    // sherpa-onnx 当前未发布 1.7B 的 GitHub release 整包，因此不填写 archive 字段。
+    requiredFiles: [
+      'conv_frontend.onnx',
+      'encoder.int8.onnx',
+      'decoder.int8.onnx',
+      'tokenizer/vocab.json',
+      'tokenizer/merges.txt',
+    ],
+  },
 };
 
-/** 整包源（ghproxy/github）的 tar.bz2 下载 URL。 */
+/** 模型实际支持的下载源；无 release 整包时仅返回 ModelScope。 */
+export function getQwenSupportedSources(id: QwenModelId): QwenModelSource[] {
+  const spec = QWEN_MODELS[id];
+  return spec.releasePath && spec.archiveName
+    ? [...QWEN_SOURCE_ORDER]
+    : ['modelscope'];
+}
+
+/** 整包源（ghproxy/github）的 tar.bz2 下载 URL；无整包资产返回 null。 */
 export function getQwenArchiveUrl(
   spec: QwenModelSpec,
   source: 'ghproxy' | 'github',
-): string {
+): string | null {
+  if (!spec.releasePath || !spec.archiveName) return null;
   const github = `${getGithubBase()}/${spec.releasePath}/${spec.archiveName}`;
   return source === 'ghproxy' ? `${getGithubProxyPrefix()}/${github}` : github;
 }

--- a/main/helpers/qwenModelCatalog.ts
+++ b/main/helpers/qwenModelCatalog.ts
@@ -1,7 +1,12 @@
 import path from 'path';
 import fs from 'fs';
 import { app } from 'electron';
-import { resolveBundledVadPath } from './modelImport';
+import {
+  resolveBundledVadPath,
+  validateModelLayoutWithSizes,
+  type LayoutCheckResult,
+  type ModelFileSizeExpectation,
+} from './modelImport';
 import { resolveModelRoot } from './storagePaths';
 import {
   getGithubBase,
@@ -68,6 +73,8 @@ export function getQwenSourceOrder(
 export interface QwenModelScopeFile {
   remote: string;
   local: string;
+  /** 固定 revision 上的官方文件大小，用于下载完整性与模型槽身份校验。 */
+  size: number;
 }
 
 /**
@@ -83,7 +90,9 @@ export interface QwenModelSpec {
   approxInstallBytes: number;
   /** ModelScope 仓库 id（逐文件国内源）。 */
   modelScopeRepo: string;
-  /** ModelScope 逐文件清单（remote→local）。 */
+  /** 固定 ModelScope revision，确保 catalog 大小不会随 master 漂移。 */
+  modelScopeRevision: string;
+  /** ModelScope 逐文件清单（remote→local + 精确大小）。 */
   modelScopeFiles: QwenModelScopeFile[];
   /**
    * GitHub release 路径（owner/repo/releases/download/tag），用于整包源拼 URL。
@@ -104,6 +113,41 @@ const QWEN_0_6B_RELEASE_PATH =
   'k2-fsa/sherpa-onnx/releases/download/asr-models';
 /** sherpa-onnx 的 Qwen3-ASR onnx 即源自该 ModelScope 仓库（k2-fsa 据此打包 tar.bz2）。 */
 const QWEN_MS_REPO = 'zengshuishui/Qwen3-ASR-onnx';
+/** 与下方精确文件大小对应的不可变 ModelScope revision。 */
+const QWEN_MS_REVISION = '9c182309f7bb075f241424441add9e16c5086dfb';
+
+const QWEN_SHARED_TOKENIZER_FILES: QwenModelScopeFile[] = [
+  {
+    remote: 'tokenizer/vocab.json',
+    local: 'tokenizer/vocab.json',
+    size: 2_776_833,
+  },
+  {
+    remote: 'tokenizer/merges.txt',
+    local: 'tokenizer/merges.txt',
+    size: 1_671_853,
+  },
+  {
+    remote: 'tokenizer/tokenizer_config.json',
+    local: 'tokenizer/tokenizer_config.json',
+    size: 12_487,
+  },
+  {
+    remote: 'tokenizer/config.json',
+    local: 'tokenizer/config.json',
+    size: 6_193,
+  },
+  {
+    remote: 'tokenizer/chat_template.json',
+    local: 'tokenizer/chat_template.json',
+    size: 1_161,
+  },
+  {
+    remote: 'tokenizer/preprocessor_config.json',
+    local: 'tokenizer/preprocessor_config.json',
+    size: 330,
+  },
+];
 
 export const QWEN_MODELS: Record<QwenModelId, QwenModelSpec> = {
   'qwen3-asr-0.6b': {
@@ -111,36 +155,36 @@ export const QWEN_MODELS: Record<QwenModelId, QwenModelSpec> = {
     dirName: 'qwen3-asr-0.6b',
     approxInstallBytes: 1_020_000_000,
     modelScopeRepo: QWEN_MS_REPO,
+    modelScopeRevision: QWEN_MS_REVISION,
     modelScopeFiles: [
-      { remote: 'model_0.6B/conv_frontend.onnx', local: 'conv_frontend.onnx' },
-      { remote: 'model_0.6B/encoder.int8.onnx', local: 'encoder.int8.onnx' },
-      { remote: 'model_0.6B/decoder.int8.onnx', local: 'decoder.int8.onnx' },
-      { remote: 'tokenizer/vocab.json', local: 'tokenizer/vocab.json' },
-      { remote: 'tokenizer/merges.txt', local: 'tokenizer/merges.txt' },
       {
-        remote: 'tokenizer/tokenizer_config.json',
-        local: 'tokenizer/tokenizer_config.json',
-      },
-      { remote: 'tokenizer/config.json', local: 'tokenizer/config.json' },
-      {
-        remote: 'tokenizer/chat_template.json',
-        local: 'tokenizer/chat_template.json',
+        remote: 'model_0.6B/conv_frontend.onnx',
+        local: 'conv_frontend.onnx',
+        size: 44_148_281,
       },
       {
-        remote: 'tokenizer/preprocessor_config.json',
-        local: 'tokenizer/preprocessor_config.json',
+        remote: 'model_0.6B/encoder.int8.onnx',
+        local: 'encoder.int8.onnx',
+        size: 182_491_662,
       },
+      {
+        remote: 'model_0.6B/decoder.int8.onnx',
+        local: 'decoder.int8.onnx',
+        size: 755_914_231,
+      },
+      ...QWEN_SHARED_TOKENIZER_FILES,
     ],
     releasePath: QWEN_0_6B_RELEASE_PATH,
     archiveName: QWEN_0_6B_ARCHIVE,
     archiveInnerDir: QWEN_0_6B_INNER,
-    // tokenizer 是目录；以其中两个关键文件作为安装完整性标记。
+    // sherpa-onnx v1.13.2 会显式校验 tokenizer_config.json，三项缺一不可。
     requiredFiles: [
       'conv_frontend.onnx',
       'encoder.int8.onnx',
       'decoder.int8.onnx',
       'tokenizer/vocab.json',
       'tokenizer/merges.txt',
+      'tokenizer/tokenizer_config.json',
     ],
   },
   'qwen3-asr-1.7b': {
@@ -149,25 +193,24 @@ export const QWEN_MODELS: Record<QwenModelId, QwenModelSpec> = {
     // ModelScope int8 三件套 + tokenizer 实际合计约 2.40 GB（十进制）。
     approxInstallBytes: 2_405_000_000,
     modelScopeRepo: QWEN_MS_REPO,
+    modelScopeRevision: QWEN_MS_REVISION,
     modelScopeFiles: [
-      { remote: 'model_1.7B/conv_frontend.onnx', local: 'conv_frontend.onnx' },
-      { remote: 'model_1.7B/encoder.int8.onnx', local: 'encoder.int8.onnx' },
-      { remote: 'model_1.7B/decoder.int8.onnx', local: 'decoder.int8.onnx' },
-      { remote: 'tokenizer/vocab.json', local: 'tokenizer/vocab.json' },
-      { remote: 'tokenizer/merges.txt', local: 'tokenizer/merges.txt' },
       {
-        remote: 'tokenizer/tokenizer_config.json',
-        local: 'tokenizer/tokenizer_config.json',
-      },
-      { remote: 'tokenizer/config.json', local: 'tokenizer/config.json' },
-      {
-        remote: 'tokenizer/chat_template.json',
-        local: 'tokenizer/chat_template.json',
+        remote: 'model_1.7B/conv_frontend.onnx',
+        local: 'conv_frontend.onnx',
+        size: 48_080_441,
       },
       {
-        remote: 'tokenizer/preprocessor_config.json',
-        local: 'tokenizer/preprocessor_config.json',
+        remote: 'model_1.7B/encoder.int8.onnx',
+        local: 'encoder.int8.onnx',
+        size: 314_222_162,
       },
+      {
+        remote: 'model_1.7B/decoder.int8.onnx',
+        local: 'decoder.int8.onnx',
+        size: 2_037_458_645,
+      },
+      ...QWEN_SHARED_TOKENIZER_FILES,
     ],
     // sherpa-onnx 当前未发布 1.7B 的 GitHub release 整包，因此不填写 archive 字段。
     requiredFiles: [
@@ -176,6 +219,7 @@ export const QWEN_MODELS: Record<QwenModelId, QwenModelSpec> = {
       'decoder.int8.onnx',
       'tokenizer/vocab.json',
       'tokenizer/merges.txt',
+      'tokenizer/tokenizer_config.json',
     ],
   },
 };
@@ -203,12 +247,12 @@ export function getQwenModelScopeFileUrl(
   spec: QwenModelSpec,
   remote: string,
 ): string {
-  return `${getModelScopeBase()}/models/${spec.modelScopeRepo}/resolve/master/${remote}`;
+  return `${getModelScopeBase()}/models/${spec.modelScopeRepo}/resolve/${spec.modelScopeRevision}/${remote}`;
 }
 
 /** ModelScope 文件树 API（取各文件 size 以计算总进度）。 */
 export function getQwenModelScopeTreeUrl(spec: QwenModelSpec): string {
-  return `${getModelScopeBase()}/api/v1/models/${spec.modelScopeRepo}/repo/files?Revision=master&Recursive=true`;
+  return `${getModelScopeBase()}/api/v1/models/${spec.modelScopeRepo}/repo/files?Revision=${spec.modelScopeRevision}&Recursive=true`;
 }
 
 export function getQwenModelDir(id: QwenModelId): string {
@@ -217,11 +261,36 @@ export function getQwenModelDir(id: QwenModelId): string {
   return dir;
 }
 
+/** 运行时必需文件及其固定 revision 官方大小。 */
+export function getQwenRequiredFileExpectations(
+  id: QwenModelId,
+): ModelFileSizeExpectation[] {
+  const spec = QWEN_MODELS[id];
+  const byLocal = new Map(
+    spec.modelScopeFiles.map((file) => [file.local, file]),
+  );
+  return spec.requiredFiles.map((requiredPath) => {
+    const file = byLocal.get(requiredPath);
+    if (!file) {
+      throw new Error(
+        `qwen catalog missing size metadata for ${id}: ${requiredPath}`,
+      );
+    }
+    return { path: requiredPath, size: file.size };
+  });
+}
+
+/** 检查 Qwen 目录是否完整且确实属于指定模型槽位。 */
+export function validateQwenModelLayout(
+  id: QwenModelId,
+  dir: string,
+): LayoutCheckResult {
+  return validateModelLayoutWithSizes(dir, getQwenRequiredFileExpectations(id));
+}
+
 export function isQwenModelInstalled(id: QwenModelId): boolean {
   const dir = path.join(getQwenModelsRoot(), QWEN_MODELS[id].dirName);
-  return QWEN_MODELS[id].requiredFiles.every((f) =>
-    fs.existsSync(path.join(dir, f)),
-  );
+  return validateQwenModelLayout(id, dir).ok;
 }
 
 /** 四件套绝对路径（供 adapter 注入 worker 模型请求；tokenizer 为目录）。 */

--- a/main/helpers/qwenModelDownloader.ts
+++ b/main/helpers/qwenModelDownloader.ts
@@ -12,6 +12,7 @@ import {
   QwenModelSpec,
   QWEN_DEFAULT_SOURCE,
   getQwenSourceOrder,
+  getQwenSupportedSources,
   getQwenArchiveUrl,
   getQwenModelScopeFileUrl,
   getQwenModelScopeTreeUrl,
@@ -85,9 +86,10 @@ function fetchJson<T>(url: string): Promise<T> {
 }
 
 /**
- * Qwen 模型下载器：整包（tar.bz2）下载 + 解包到 userData/models/qwen/<id>/。
- * 复用 downloadFileParallel（断点续传 + 多连接 + 取消），解包用 decompress（含 tarbz2 插件）。
- * 与 FunasrModelDownloader 同构（同事件名 downloadProgress / modelDownloadDetail）。
+ * Qwen 模型下载器：
+ * - ModelScope 按 catalog 逐文件下载（所有规格可用）；
+ * - 有 sherpa-onnx release 整包的规格可经 GitHub / ghproxy 下载并解包。
+ * 复用 downloadFileParallel（多连接 + 取消），与 FunasrModelDownloader 使用相同进度事件。
  */
 export class QwenModelDownloader {
   private abortController: AbortController | null = null;
@@ -200,7 +202,7 @@ export class QwenModelDownloader {
 
     let lastError: unknown = null;
     // 按所选源优先、其余按国内优先顺序回退（modelscope → ghproxy → github）。
-    for (const src of getQwenSourceOrder(source)) {
+    for (const src of getQwenSourceOrder(source, getQwenSupportedSources(id))) {
       try {
         if (src === 'modelscope') {
           await this.downloadFromModelScope(spec);
@@ -323,9 +325,15 @@ export class QwenModelDownloader {
     spec: QwenModelSpec,
     source: 'ghproxy' | 'github',
   ): Promise<void> {
+    if (!spec.archiveName) {
+      throw new Error(`archive source is unavailable for ${spec.id}`);
+    }
     const destDir = getQwenModelDir(spec.id);
     const tmp = path.join(getQwenModelsRoot(), spec.archiveName);
     const url = getQwenArchiveUrl(spec, source);
+    if (!url) {
+      throw new Error(`archive source is unavailable for ${spec.id}`);
+    }
 
     this.update({
       status: 'downloading',

--- a/main/helpers/qwenModelDownloader.ts
+++ b/main/helpers/qwenModelDownloader.ts
@@ -25,9 +25,12 @@ import {
   RangeNotSupportedError,
 } from './download/parallelDownloader';
 import { extractArchive } from './download/extractArchive';
+import { assertFileSize } from './download/resumeIntegrity';
+import { fetchJson } from './download/fetchJson';
 
 const CONNECT_TIMEOUT = 30_000;
 const CANCELLED = 'Download cancelled';
+const MAX_REDIRECTS = 5;
 
 /** 进度 key：qwen:<modelId>，与 funasr:<id> / ct2:<id> 同构，渲染层按前缀路由。 */
 export function getQwenProgressKey(id: QwenModelId): string {
@@ -45,44 +48,9 @@ interface MsFileEntry {
   Type: string;
 }
 
-/** 拉取 JSON（跟随 3xx 重定向），用于 ModelScope 文件树 API。 */
-function fetchJson<T>(url: string): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const parsed = new URL(url);
-    const protocol = parsed.protocol === 'https:' ? https : http;
-    const request = protocol.get(
-      url,
-      { headers: { 'User-Agent': 'SmartSub-Electron' } },
-      (response) => {
-        if (
-          response.statusCode &&
-          response.statusCode >= 300 &&
-          response.statusCode < 400 &&
-          response.headers.location
-        ) {
-          fetchJson<T>(resolveRedirectUrl(url, response.headers.location))
-            .then(resolve)
-            .catch(reject);
-          return;
-        }
-        if (!response.statusCode || response.statusCode >= 400) {
-          reject(new Error(`HTTP Error: ${response.statusCode}`));
-          return;
-        }
-        const chunks: Buffer[] = [];
-        response.on('data', (c: Buffer) => chunks.push(c));
-        response.on('end', () => {
-          try {
-            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')) as T);
-          } catch (e) {
-            reject(e);
-          }
-        });
-      },
-    );
-    request.on('error', reject);
-    request.setTimeout(CONNECT_TIMEOUT);
-  });
+interface QwenDownloadSession {
+  key: string;
+  controller: AbortController;
 }
 
 /**
@@ -92,9 +60,8 @@ function fetchJson<T>(url: string): Promise<T> {
  * 复用 downloadFileParallel（多连接 + 取消），与 FunasrModelDownloader 使用相同进度事件。
  */
 export class QwenModelDownloader {
-  private abortController: AbortController | null = null;
+  private activeSession: QwenDownloadSession | null = null;
   private mainWindow: BrowserWindow | null = null;
-  private currentKey: string | null = null;
   private progress: ModelDownloadProgress = {
     status: 'idle',
     progress: 0,
@@ -113,70 +80,79 @@ export class QwenModelDownloader {
   }
 
   cancel(): void {
-    if (this.abortController) {
-      this.abortController.abort();
-      this.abortController = null;
+    const session = this.activeSession;
+    if (session && !session.controller.signal.aborted) {
+      session.controller.abort();
+      this.progress = { ...this.progress, status: 'idle' };
+      this.send(session);
     }
-    this.progress = { ...this.progress, status: 'idle' };
-    this.currentKey = null;
   }
 
-  private send(): void {
-    if (this.mainWindow && !this.mainWindow.isDestroyed() && this.currentKey) {
+  private send(session: QwenDownloadSession): void {
+    if (
+      this.activeSession === session &&
+      this.mainWindow &&
+      !this.mainWindow.isDestroyed()
+    ) {
       const ratio =
         this.progress.total > 0
           ? this.progress.downloaded / this.progress.total
           : 0;
       this.mainWindow.webContents.send(
         'downloadProgress',
-        this.currentKey,
+        session.key,
         Math.min(ratio, 0.99),
       );
       this.mainWindow.webContents.send(
         'modelDownloadDetail',
-        this.currentKey,
+        session.key,
         this.progress,
       );
     }
   }
 
-  private update(p: Partial<ModelDownloadProgress>): void {
+  private update(
+    session: QwenDownloadSession,
+    p: Partial<ModelDownloadProgress>,
+  ): void {
+    if (this.activeSession !== session) return;
     this.progress = { ...this.progress, ...p };
     if (this.progress.total > 0) {
       this.progress.progress =
         (this.progress.downloaded / this.progress.total) * 100;
     }
-    this.send();
+    this.send(session);
   }
 
-  private sendFinal(key: string, value: number): void {
-    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
-      this.mainWindow.webContents.send('downloadProgress', key, value);
+  private sendFinal(session: QwenDownloadSession, value: number): void {
+    if (
+      this.activeSession === session &&
+      this.mainWindow &&
+      !this.mainWindow.isDestroyed()
+    ) {
+      this.mainWindow.webContents.send('downloadProgress', session.key, value);
       this.mainWindow.webContents.send(
         'modelDownloadDetail',
-        key,
+        session.key,
         this.progress,
       );
     }
   }
 
   /** 解包阶段进度：复用 downloadProgress 让进度条继续走，status='extracting' 供 UI 显示「解包中」。 */
-  private sendExtract(ratio: number): void {
+  private sendExtract(session: QwenDownloadSession, ratio: number): void {
+    if (this.activeSession !== session) return;
     const capped = Math.min(ratio, 0.99);
     this.progress = {
       ...this.progress,
       status: 'extracting',
       progress: Math.round(capped * 100),
     };
-    if (this.mainWindow && !this.mainWindow.isDestroyed() && this.currentKey) {
-      this.mainWindow.webContents.send(
-        'downloadProgress',
-        this.currentKey,
-        capped,
-      );
+    if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+      this.mainWindow.webContents.send('downloadProgress', session.key, capped);
       this.mainWindow.webContents.send(
         'modelDownloadDetail',
-        this.currentKey,
+        session.key,
         this.progress,
       );
     }
@@ -186,13 +162,18 @@ export class QwenModelDownloader {
     id: QwenModelId,
     source: QwenModelSource = QWEN_DEFAULT_SOURCE,
   ): Promise<boolean> {
+    if (this.activeSession) {
+      throw new Error('another qwen model download is in progress');
+    }
     if (isQwenModelInstalled(id)) return true;
     const spec = QWEN_MODELS[id];
-    const key = getQwenProgressKey(id);
-    this.currentKey = key;
-    this.abortController = new AbortController();
+    const session: QwenDownloadSession = {
+      key: getQwenProgressKey(id),
+      controller: new AbortController(),
+    };
+    this.activeSession = session;
 
-    this.update({
+    this.update(session, {
       status: 'downloading',
       downloaded: 0,
       total: 0,
@@ -200,64 +181,87 @@ export class QwenModelDownloader {
       error: undefined,
     });
 
-    let lastError: unknown = null;
-    // 按所选源优先、其余按国内优先顺序回退（modelscope → ghproxy → github）。
-    for (const src of getQwenSourceOrder(source, getQwenSupportedSources(id))) {
-      try {
-        if (src === 'modelscope') {
-          await this.downloadFromModelScope(spec);
-        } else {
-          await this.downloadFromArchive(spec, src);
-        }
+    try {
+      let lastError: unknown = null;
+      // 按所选源优先、其余按国内优先顺序回退（modelscope → ghproxy → github）。
+      for (const src of getQwenSourceOrder(
+        source,
+        getQwenSupportedSources(id),
+      )) {
+        try {
+          if (session.controller.signal.aborted) {
+            throw new Error(CANCELLED);
+          }
+          if (src === 'modelscope') {
+            await this.downloadFromModelScope(spec, session);
+          } else {
+            await this.downloadFromArchive(spec, src, session);
+          }
 
-        if (!isQwenModelInstalled(id)) {
-          throw new Error(
-            `download finished but required files missing for ${id}: ${spec.requiredFiles.join(', ')}`,
-          );
+          if (!isQwenModelInstalled(id)) {
+            throw new Error(
+              `download finished but required files are incomplete or wrong-sized for ${id}: ${spec.requiredFiles.join(', ')}`,
+            );
+          }
+          this.progress = {
+            ...this.progress,
+            status: 'completed',
+            progress: 100,
+          };
+          this.sendFinal(session, 1);
+          logMessage(`qwen model ${id} installed from ${src}`, 'info');
+          return true;
+        } catch (error) {
+          lastError = error;
+          const msg = error instanceof Error ? error.message : String(error);
+          if (session.controller.signal.aborted || msg === CANCELLED) {
+            this.progress = { ...this.progress, status: 'idle' };
+            this.sendFinal(session, 0);
+            throw new Error(CANCELLED);
+          }
+          logMessage(`qwen model ${id} from ${src} failed: ${msg}`, 'warning');
         }
-        this.progress = {
-          ...this.progress,
-          status: 'completed',
-          progress: 100,
-        };
-        this.sendFinal(key, 1);
-        this.currentKey = null;
-        logMessage(`qwen model ${id} installed from ${src}`, 'info');
-        return true;
-      } catch (error) {
-        lastError = error;
-        const msg = error instanceof Error ? error.message : String(error);
-        if (msg === CANCELLED) {
-          this.progress = { ...this.progress, status: 'idle' };
-          this.sendFinal(key, 1);
-          this.currentKey = null;
-          throw error;
-        }
-        logMessage(`qwen model ${id} from ${src} failed: ${msg}`, 'warning');
+      }
+
+      this.progress = {
+        ...this.progress,
+        status: 'error',
+        error:
+          lastError instanceof Error ? lastError.message : String(lastError),
+      };
+      this.sendFinal(session, 0);
+      throw lastError instanceof Error
+        ? lastError
+        : new Error(String(lastError));
+    } finally {
+      if (this.activeSession === session) {
+        this.activeSession = null;
       }
     }
-
-    this.progress = {
-      ...this.progress,
-      status: 'error',
-      error: lastError instanceof Error ? lastError.message : String(lastError),
-    };
-    this.sendFinal(key, 0);
-    this.currentKey = null;
-    throw lastError instanceof Error ? lastError : new Error(String(lastError));
   }
 
   /**
    * ModelScope 国内源：逐文件直下到模型目录，免解包（国内 CDN 最快）。
-   * 先拉文件树拿各文件大小以计算总进度；已存在且大小吻合的文件跳过（续传友好）。
+   * 文件大小固定在 catalog revision；文件树用于交叉校验远端元数据。
+   * 已存在且大小吻合的文件跳过（续传友好）。
    */
-  private async downloadFromModelScope(spec: QwenModelSpec): Promise<void> {
+  private async downloadFromModelScope(
+    spec: QwenModelSpec,
+    session: QwenDownloadSession,
+  ): Promise<void> {
     const destDir = getQwenModelDir(spec.id);
+    const signal = session.controller.signal;
 
     let sizeByPath = new Map<string, number>();
     try {
       const tree = await fetchJson<{ Data?: { Files?: MsFileEntry[] } }>(
         getQwenModelScopeTreeUrl(spec),
+        {
+          signal,
+          headers: { 'User-Agent': 'SmartSub-Electron' },
+          timeoutMs: CONNECT_TIMEOUT,
+          cancelMessage: CANCELLED,
+        },
       );
       sizeByPath = new Map(
         (tree.Data?.Files ?? [])
@@ -265,17 +269,24 @@ export class QwenModelDownloader {
           .map((e) => [e.Path, e.Size ?? 0]),
       );
     } catch (e) {
-      // 树拉取失败仅导致进度退化（按 0 计），不阻断逐文件下载。
+      if (signal.aborted) throw new Error(CANCELLED);
+      // 树拉取失败不阻断固定 revision 的逐文件下载；进度仍使用 catalog 大小。
       logMessage(`qwen modelscope tree fetch failed: ${String(e)}`, 'warning');
     }
 
-    const files = spec.modelScopeFiles.map((f) => ({
-      ...f,
-      size: sizeByPath.get(f.remote) ?? 0,
-    }));
+    for (const file of spec.modelScopeFiles) {
+      const remoteSize = sizeByPath.get(file.remote);
+      if (remoteSize !== undefined && remoteSize !== file.size) {
+        throw new Error(
+          `qwen catalog size mismatch for ${file.remote}: remote ${remoteSize}, expected ${file.size}`,
+        );
+      }
+    }
+
+    const files = spec.modelScopeFiles;
     const total = files.reduce((s, f) => s + f.size, 0);
     let downloaded = 0;
-    this.update({
+    this.update(session, {
       status: 'downloading',
       downloaded: 0,
       total,
@@ -284,15 +295,12 @@ export class QwenModelDownloader {
     });
 
     for (const f of files) {
+      if (signal.aborted) throw new Error(CANCELLED);
       const dest = path.join(destDir, f.local);
       fs.mkdirSync(path.dirname(dest), { recursive: true });
-      if (
-        f.size > 0 &&
-        fs.existsSync(dest) &&
-        fs.statSync(dest).size === f.size
-      ) {
+      if (fs.existsSync(dest) && fs.statSync(dest).size === f.size) {
         downloaded += f.size;
-        this.update({ downloaded });
+        this.update(session, { downloaded });
         continue;
       }
       const url = getQwenModelScopeFileUrl(spec, f.remote);
@@ -300,23 +308,34 @@ export class QwenModelDownloader {
         await downloadFileParallel({
           url,
           destPath: dest,
-          signal: this.abortController?.signal,
+          signal,
           headers: { 'User-Agent': 'SmartSub-Electron' },
           onProgress: (thisFile) =>
-            this.update({ downloaded: downloaded + thisFile, total }),
+            this.update(session, {
+              downloaded: downloaded + thisFile,
+              total,
+            }),
           log: (m, l) => logMessage(m, l),
         });
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
-        if (msg === CANCELLED) throw error;
+        if (signal.aborted || msg === CANCELLED) {
+          throw new Error(CANCELLED);
+        }
         if (error instanceof RangeNotSupportedError) {
-          await this.downloadSingle(url, dest, this.abortController?.signal);
+          await this.downloadSingle(url, dest, signal, (thisFile) =>
+            this.update(session, {
+              downloaded: downloaded + thisFile,
+              total,
+            }),
+          );
         } else {
           throw error;
         }
       }
+      assertFileSize(dest, f.size, `${spec.id}/${f.local}`);
       downloaded += f.size;
-      this.update({ downloaded });
+      this.update(session, { downloaded });
     }
   }
 
@@ -324,6 +343,7 @@ export class QwenModelDownloader {
   private async downloadFromArchive(
     spec: QwenModelSpec,
     source: 'ghproxy' | 'github',
+    session: QwenDownloadSession,
   ): Promise<void> {
     if (!spec.archiveName) {
       throw new Error(`archive source is unavailable for ${spec.id}`);
@@ -335,7 +355,7 @@ export class QwenModelDownloader {
       throw new Error(`archive source is unavailable for ${spec.id}`);
     }
 
-    this.update({
+    this.update(session, {
       status: 'downloading',
       downloaded: 0,
       total: 0,
@@ -345,20 +365,20 @@ export class QwenModelDownloader {
 
     try {
       if (fs.existsSync(tmp)) fs.rmSync(tmp, { force: true });
-      await this.downloadArchive(url, tmp);
+      await this.downloadArchive(url, tmp, session);
 
       // 解包到独立进程（system tar），主进程事件循环不阻塞 → 不再「卡住」；
       // 失败回退 bundled decompress。strip 顶层目录、过滤 test_wavs。
       this.progress = { ...this.progress, status: 'extracting' };
-      this.sendExtract(0);
+      this.sendExtract(session, 0);
       await extractArchive({
         archivePath: tmp,
         destDir,
         strip: 1,
         excludeContains: 'test_wavs',
         approxTotalBytes: spec.approxInstallBytes,
-        signal: this.abortController?.signal,
-        onProgress: (ratio) => this.sendExtract(ratio),
+        signal: session.controller.signal,
+        onProgress: (ratio) => this.sendExtract(session, ratio),
       });
     } finally {
       // 无论成功/失败/取消都清理临时整包，避免污染 models 根目录。
@@ -367,79 +387,167 @@ export class QwenModelDownloader {
   }
 
   /** 并行续传下载整包；服务端不支持 Range 时回退单连接。 */
-  private async downloadArchive(url: string, dest: string): Promise<void> {
+  private async downloadArchive(
+    url: string,
+    dest: string,
+    session: QwenDownloadSession,
+  ): Promise<void> {
+    const signal = session.controller.signal;
     try {
       await downloadFileParallel({
         url,
         destPath: dest,
-        signal: this.abortController?.signal,
+        signal,
         headers: { 'User-Agent': 'SmartSub-Electron' },
-        onProgress: (downloaded, total) => this.update({ downloaded, total }),
+        onProgress: (downloaded, total) =>
+          this.update(session, { downloaded, total }),
         log: (m, l) => logMessage(m, l),
       });
     } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (signal.aborted || msg === CANCELLED) {
+        throw new Error(CANCELLED);
+      }
       if (error instanceof RangeNotSupportedError) {
-        await this.downloadSingle(url, dest, this.abortController?.signal);
+        await this.downloadSingle(url, dest, signal, (downloaded, total) =>
+          this.update(session, { downloaded, total }),
+        );
         return;
       }
       throw error;
     }
   }
 
-  private downloadSingle(
+  private async downloadSingle(
     url: string,
     destPath: string,
     signal?: AbortSignal,
+    onProgress?: (downloaded: number, total: number) => void,
   ): Promise<void> {
+    const working = `${destPath}.single`;
+    await fs.promises.rm(working, { force: true });
+    try {
+      await this.downloadSingleRequest(url, working, signal, onProgress, 0);
+      if (signal?.aborted) throw new Error(CANCELLED);
+      await fs.promises.rm(destPath, { force: true });
+      await fs.promises.rename(working, destPath);
+    } finally {
+      await fs.promises.rm(working, { force: true }).catch(() => {});
+    }
+  }
+
+  private downloadSingleRequest(
+    url: string,
+    workingPath: string,
+    signal: AbortSignal | undefined,
+    onProgress: ((downloaded: number, total: number) => void) | undefined,
+    redirects: number,
+  ): Promise<void> {
+    if (signal?.aborted) return Promise.reject(new Error(CANCELLED));
+
     return new Promise((resolve, reject) => {
       const parsed = new URL(url);
       const protocol = parsed.protocol === 'https:' ? https : http;
-      const onAbort = () => {
-        req.destroy();
-        reject(new Error(CANCELLED));
+      let settled = false;
+      let response: http.IncomingMessage | null = null;
+      let out: fs.WriteStream | null = null;
+      let req: http.ClientRequest;
+
+      const cleanup = () => signal?.removeEventListener('abort', onAbort);
+      const finish = (error?: unknown) => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if (error) {
+          response?.destroy();
+          out?.destroy();
+          reject(error instanceof Error ? error : new Error(String(error)));
+        } else {
+          resolve();
+        }
       };
-      signal?.addEventListener('abort', onAbort, { once: true });
-      const req = protocol.get(
+      const onAbort = () => {
+        const error = new Error(CANCELLED);
+        req.destroy(error);
+        finish(error);
+      };
+      req = protocol.get(
         url,
         { headers: { 'User-Agent': 'SmartSub-Electron' } },
-        (response) => {
+        (incoming) => {
+          response = incoming;
           if (
-            response.statusCode &&
-            response.statusCode >= 300 &&
-            response.statusCode < 400 &&
-            response.headers.location
+            incoming.statusCode &&
+            incoming.statusCode >= 300 &&
+            incoming.statusCode < 400 &&
+            incoming.headers.location
           ) {
-            signal?.removeEventListener('abort', onAbort);
-            this.downloadSingle(
-              resolveRedirectUrl(url, response.headers.location),
-              destPath,
+            incoming.resume();
+            if (redirects >= MAX_REDIRECTS) {
+              finish(new Error('Too many redirects while downloading'));
+              return;
+            }
+            settled = true;
+            cleanup();
+            this.downloadSingleRequest(
+              resolveRedirectUrl(url, incoming.headers.location),
+              workingPath,
               signal,
-            )
-              .then(resolve)
-              .catch(reject);
+              onProgress,
+              redirects + 1,
+            ).then(resolve, reject);
             return;
           }
-          if (!response.statusCode || response.statusCode >= 400) {
-            reject(new Error(`HTTP Error: ${response.statusCode}`));
+          if (
+            !incoming.statusCode ||
+            incoming.statusCode < 200 ||
+            incoming.statusCode >= 300
+          ) {
+            incoming.resume();
+            finish(new Error(`HTTP Error: ${incoming.statusCode}`));
             return;
           }
-          const total = Number(response.headers['content-length'] || 0);
+
+          const total = Number(incoming.headers['content-length'] || 0);
           let downloaded = 0;
-          response.on('data', (c: Buffer) => {
-            downloaded += c.length;
-            this.update({ downloaded, total });
+          let streamFinished = false;
+          incoming.on('data', (chunk: Buffer) => {
+            downloaded += chunk.length;
+            onProgress?.(downloaded, total);
           });
-          const out = fs.createWriteStream(destPath, { flags: 'w' });
-          response.pipe(out);
+          incoming.on('aborted', () =>
+            finish(new Error('download response aborted before completion')),
+          );
+          incoming.on('error', finish);
+
+          out = fs.createWriteStream(workingPath, { flags: 'w' });
+          incoming.pipe(out);
           out.on('finish', () => {
-            signal?.removeEventListener('abort', onAbort);
-            resolve();
+            if (total > 0 && downloaded !== total) {
+              finish(
+                new Error(
+                  `single download size mismatch: got ${downloaded}, expected ${total}`,
+                ),
+              );
+              return;
+            }
+            streamFinished = true;
           });
-          out.on('error', reject);
+          out.on('close', () => {
+            if (streamFinished) finish();
+            else if (!settled) {
+              finish(new Error('download stream closed before completion'));
+            }
+          });
+          out.on('error', finish);
         },
       );
-      req.on('error', reject);
-      req.setTimeout(CONNECT_TIMEOUT);
+      req.on('error', finish);
+      req.setTimeout(CONNECT_TIMEOUT, () => {
+        req.destroy(new Error('download request timeout'));
+      });
+      signal?.addEventListener('abort', onAbort, { once: true });
+      if (signal?.aborted) onAbort();
     });
   }
 }

--- a/main/helpers/systemInfoManager.ts
+++ b/main/helpers/systemInfoManager.ts
@@ -57,6 +57,7 @@ import {
   getQwenModelsRoot,
   getQwenArchiveUrl,
   getQwenSupportedSources,
+  validateQwenModelLayout,
 } from './qwenModelCatalog';
 import {
   getFireRedModelDownloader,
@@ -150,6 +151,7 @@ function resolveImportPlan(
     return {
       requiredFiles: QWEN_MODELS[id].requiredFiles,
       destDir: path.join(getQwenModelsRoot(), QWEN_MODELS[id].dirName),
+      validate: (dir) => validateQwenModelLayout(id, dir),
     };
   }
   if (engine === 'fireRedAsr') {
@@ -592,7 +594,8 @@ export function setupSystemInfoManager(mainWindow: BrowserWindow) {
     qwenModelDownloader.cancel();
     fireRedModelDownloader.cancel();
     ttsModelDownloader.cancel();
-    downloadingModels.clear();
+    // 不提前清空下载锁：各下载 session 在真正响应 abort 并退出后自行移除 key。
+    // 否则 UI 可立即启动新任务，让旧异步链复用新 controller / 混写进度与文件。
     return true;
   });
 

--- a/main/helpers/systemInfoManager.ts
+++ b/main/helpers/systemInfoManager.ts
@@ -56,6 +56,7 @@ import {
   getInstalledQwenModels,
   getQwenModelsRoot,
   getQwenArchiveUrl,
+  getQwenSupportedSources,
 } from './qwenModelCatalog';
 import {
   getFireRedModelDownloader,
@@ -374,6 +375,7 @@ export function setupSystemInfoManager(mainWindow: BrowserWindow) {
     models: (Object.keys(QWEN_MODELS) as QwenModelId[]).map((id) => ({
       id,
       installed: isQwenModelInstalled(id),
+      sources: getQwenSupportedSources(id),
     })),
   }));
 
@@ -528,13 +530,13 @@ export function setupSystemInfoManager(mainWindow: BrowserWindow) {
               url: `${getModelScopeBase()}/models/${spec.modelScopeRepo}`,
             };
           }
-          return {
-            success: true,
-            url: getQwenArchiveUrl(
-              spec,
-              source === 'github' ? 'github' : 'ghproxy',
-            ),
-          };
+          const url = getQwenArchiveUrl(
+            spec,
+            source === 'github' ? 'github' : 'ghproxy',
+          );
+          return url
+            ? { success: true, url }
+            : { success: false, error: 'sourceUnavailable' };
         }
         if (scope === 'firered') {
           const spec = FIRERED_MODELS[modelId as FireRedModelId];

--- a/renderer/components/resources/QwenModelSection.tsx
+++ b/renderer/components/resources/QwenModelSection.tsx
@@ -21,7 +21,7 @@ import SherpaModelRow from '@/components/resources/SherpaModelRow';
 import { importModelFromFolder } from 'lib/importModel';
 import { resolveModelDownloadUrl } from 'lib/resolveModelDownloadUrl';
 
-type QwenModelId = 'qwen3-asr-0.6b';
+type QwenModelId = 'qwen3-asr-0.6b' | 'qwen3-asr-1.7b';
 
 /** qwen 模型下载源（与主进程 QwenModelSource 一致）：国内优先 ModelScope。 */
 type QwenModelSource = 'modelscope' | 'ghproxy' | 'github';
@@ -30,6 +30,12 @@ const QWEN_MODEL_SOURCES: QwenModelSource[] = [
   'ghproxy',
   'github',
 ];
+const QWEN_MODEL_IDS: QwenModelId[] = ['qwen3-asr-0.6b', 'qwen3-asr-1.7b'];
+const QWEN_FALLBACK_SOURCES: Record<QwenModelId, QwenModelSource[]> = {
+  'qwen3-asr-0.6b': QWEN_MODEL_SOURCES,
+  // sherpa-onnx 暂未发布 1.7B 的 GitHub release 整包。
+  'qwen3-asr-1.7b': ['modelscope'],
+};
 const QWEN_SOURCE_STORAGE_KEY = 'qwenModelDownloadSource';
 
 function readQwenModelSource(): QwenModelSource {
@@ -44,7 +50,11 @@ interface QwenModelStatus {
   engineInstalled: boolean;
   vadInstalled: boolean;
   ready: boolean;
-  models: { id: QwenModelId; installed: boolean }[];
+  models: {
+    id: QwenModelId;
+    installed: boolean;
+    sources?: QwenModelSource[];
+  }[];
 }
 
 const QwenModelSection: React.FC<{ onUpdate?: () => void }> = ({
@@ -56,9 +66,11 @@ const QwenModelSection: React.FC<{ onUpdate?: () => void }> = ({
   const [status, setStatus] = useState<QwenModelStatus | null>(null);
   const [progress, setProgress] = useState<Record<string, number>>({});
   const [phase, setPhase] = useState<Record<string, string>>({});
-  const [downloading, setDownloading] = useState<string | null>(null);
-  const [showConfirm, setShowConfirm] = useState(false);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [downloading, setDownloading] = useState<QwenModelId | null>(null);
+  const [pickerId, setPickerId] = useState<QwenModelId | null>(null);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<QwenModelId | null>(
+    null,
+  );
   const [source, setSource] = useState<QwenModelSource>('modelscope');
 
   useEffect(() => {
@@ -110,30 +122,43 @@ const QwenModelSection: React.FC<{ onUpdate?: () => void }> = ({
     };
   }, [load, onUpdate]);
 
-  const qwenInstalled =
-    status?.models.find((m) => m.id === 'qwen3-asr-0.6b')?.installed ?? false;
+  const isInstalled = (id: QwenModelId) =>
+    status?.models.find((m) => m.id === id)?.installed ?? false;
 
-  // 下载源在「点击下载时」于气泡内选择（与各引擎统一）。
-  const sourceConfig: DownloadSourceConfig = {
-    value: source,
-    options: QWEN_MODEL_SOURCES.map((s) => ({
-      value: s,
-      label: t(`engines.qwen.modelSources.${s}`),
-    })),
-    onChange: (s) => handleSelectSource(s as QwenModelSource),
-    label: t('engines.qwen.downloadSource'),
-    confirmLabel: commonT('startDownload'),
-    hint: t(`engines.qwen.modelSourceHint.${source}`),
-    getCopyUrl: (s) => resolveModelDownloadUrl('qwen', s, 'qwen3-asr-0.6b'),
+  const supportedSources = (id: QwenModelId): QwenModelSource[] =>
+    status?.models.find((m) => m.id === id)?.sources ??
+    QWEN_FALLBACK_SOURCES[id];
+
+  const effectiveSource = (id: QwenModelId): QwenModelSource => {
+    const supported = supportedSources(id);
+    return supported.includes(source) ? source : supported[0];
   };
 
-  const doDownloadQwen = async () => {
-    setShowConfirm(false);
-    setDownloading('qwen3-asr-0.6b');
+  // 下载源在「点击下载时」于气泡内选择（与各引擎统一）。
+  const sourceConfigFor = (id: QwenModelId): DownloadSourceConfig => {
+    const sources = supportedSources(id);
+    const selected = effectiveSource(id);
+    return {
+      value: selected,
+      options: sources.map((s) => ({
+        value: s,
+        label: t(`engines.qwen.modelSources.${s}`),
+      })),
+      onChange: (s) => handleSelectSource(s as QwenModelSource),
+      label: t('engines.qwen.downloadSource'),
+      confirmLabel: commonT('startDownload'),
+      hint: t(`engines.qwen.modelSourceHint.${selected}`),
+      getCopyUrl: (s) => resolveModelDownloadUrl('qwen', s, id),
+    };
+  };
+
+  const handleDownload = async (id: QwenModelId) => {
+    setPickerId(null);
+    setDownloading(id);
     try {
       const r = await window?.ipc?.invoke('downloadQwenModel', {
-        model: 'qwen3-asr-0.6b',
-        source,
+        model: id,
+        source: effectiveSource(id),
       });
       if (r?.success) {
         await load();
@@ -149,7 +174,7 @@ const QwenModelSection: React.FC<{ onUpdate?: () => void }> = ({
       toast.error(String(e));
     } finally {
       setDownloading(null);
-      setProgress((prev) => ({ ...prev, 'qwen:qwen3-asr-0.6b': 0 }));
+      setProgress((prev) => ({ ...prev, [`qwen:${id}`]: 0 }));
     }
   };
 
@@ -158,8 +183,8 @@ const QwenModelSection: React.FC<{ onUpdate?: () => void }> = ({
     setDownloading(null);
   };
 
-  const handleImportQwen = async () => {
-    const o = await importModelFromFolder('qwen', 'qwen3-asr-0.6b');
+  const handleImport = async (id: QwenModelId) => {
+    const o = await importModelFromFolder('qwen', id);
     if (o.kind === 'success') {
       toast.success(t('importModelSuccess'), { duration: 2000 });
       await load();
@@ -171,15 +196,97 @@ const QwenModelSection: React.FC<{ onUpdate?: () => void }> = ({
     }
   };
 
-  const handleDeleteQwen = async () => {
-    setShowDeleteConfirm(false);
-    const r = await window?.ipc?.invoke('deleteQwenModel', 'qwen3-asr-0.6b');
+  const handleDelete = async (id: QwenModelId) => {
+    const r = await window?.ipc?.invoke('deleteQwenModel', id);
     if (r?.success) {
       await load();
       onUpdate?.();
     } else {
       toast.error(r?.error || 'Failed to delete model');
     }
+  };
+
+  const confirmDelete = async () => {
+    if (!confirmDeleteId) return;
+    const id = confirmDeleteId;
+    setConfirmDeleteId(null);
+    await handleDelete(id);
+  };
+
+  const renderRow = (id: QwenModelId) => {
+    const installed = isInstalled(id);
+    const isBusy = downloading === id;
+    const key = `qwen:${id}`;
+    const sourceConfig = sourceConfigFor(id);
+
+    return (
+      <SherpaModelRow
+        key={id}
+        icon={Mic}
+        name={t(`engines.qwen.models.${id}.name`)}
+        desc={t(`engines.qwen.models.${id}.desc`)}
+        installed={installed}
+        busy={isBusy}
+        progressPercent={Math.round((progress[key] ?? 0) * 100)}
+        phaseText={
+          phase[key] === 'extracting' ? t('engines.qwen.extracting') : undefined
+        }
+        progressWidthClass="w-44"
+        trailing={
+          isBusy ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="gap-1.5 text-muted-foreground"
+              onClick={handleCancel}
+            >
+              <X className="h-3.5 w-3.5" />
+              {commonT('cancel')}
+            </Button>
+          ) : installed ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              className="gap-1.5 text-muted-foreground hover:text-destructive"
+              onClick={() => setConfirmDeleteId(id)}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              {t('engines.qwen.modelDelete')}
+            </Button>
+          ) : (
+            <div className="flex items-center gap-1.5">
+              <DownloadSourcePopover
+                open={pickerId === id}
+                onOpenChange={(open) => setPickerId(open ? id : null)}
+                config={sourceConfig}
+                onConfirm={() => handleDownload(id)}
+              >
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="gap-1.5"
+                  disabled={!!downloading}
+                  onClick={() => setPickerId(id)}
+                >
+                  <Download className="h-3.5 w-3.5" />
+                  {t('engines.qwen.modelDownload')}
+                </Button>
+              </DownloadSourcePopover>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="gap-1.5 text-muted-foreground"
+                disabled={!!downloading}
+                onClick={() => handleImport(id)}
+              >
+                <Upload className="h-3.5 w-3.5" />
+                {t('importFromFolder')}
+              </Button>
+            </div>
+          )
+        }
+      />
+    );
   };
 
   return (
@@ -193,80 +300,17 @@ const QwenModelSection: React.FC<{ onUpdate?: () => void }> = ({
         </div>
         <Card>
           <CardContent className="space-y-2 p-2">
-            <SherpaModelRow
-              icon={Mic}
-              name={t('engines.qwen.models.qwen3-asr-0.6b.name')}
-              desc={t('engines.qwen.models.qwen3-asr-0.6b.desc')}
-              installed={qwenInstalled}
-              busy={downloading === 'qwen3-asr-0.6b'}
-              progressPercent={Math.round(
-                (progress['qwen:qwen3-asr-0.6b'] ?? 0) * 100,
-              )}
-              phaseText={
-                phase['qwen:qwen3-asr-0.6b'] === 'extracting'
-                  ? t('engines.qwen.extracting')
-                  : undefined
-              }
-              progressWidthClass="w-44"
-              trailing={
-                downloading === 'qwen3-asr-0.6b' ? (
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="gap-1.5 text-muted-foreground"
-                    onClick={handleCancel}
-                  >
-                    <X className="h-3.5 w-3.5" />
-                    {commonT('cancel')}
-                  </Button>
-                ) : qwenInstalled ? (
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    className="gap-1.5 text-muted-foreground hover:text-destructive"
-                    onClick={() => setShowDeleteConfirm(true)}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                    {t('engines.qwen.modelDelete')}
-                  </Button>
-                ) : (
-                  <div className="flex items-center gap-1.5">
-                    <DownloadSourcePopover
-                      open={showConfirm}
-                      onOpenChange={setShowConfirm}
-                      config={sourceConfig}
-                      onConfirm={doDownloadQwen}
-                    >
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        className="gap-1.5"
-                        disabled={!!downloading}
-                        onClick={() => setShowConfirm(true)}
-                      >
-                        <Download className="h-3.5 w-3.5" />
-                        {t('engines.qwen.modelDownload')}
-                      </Button>
-                    </DownloadSourcePopover>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="gap-1.5 text-muted-foreground"
-                      disabled={!!downloading}
-                      onClick={handleImportQwen}
-                    >
-                      <Upload className="h-3.5 w-3.5" />
-                      {t('importFromFolder')}
-                    </Button>
-                  </div>
-                )
-              }
-            />
+            {QWEN_MODEL_IDS.map(renderRow)}
           </CardContent>
         </Card>
       </section>
 
-      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+      <AlertDialog
+        open={confirmDeleteId !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmDeleteId(null);
+        }}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{commonT('confirmDeleteModel')}</AlertDialogTitle>
@@ -281,7 +325,7 @@ const QwenModelSection: React.FC<{ onUpdate?: () => void }> = ({
             </AlertDialogCancel>
             <AlertDialogAction
               className="gap-1.5 bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              onClick={handleDeleteQwen}
+              onClick={confirmDelete}
             >
               <Trash2 className="h-4 w-4" />
               {commonT('delete')}

--- a/renderer/public/locales/en/resources.json
+++ b/renderer/public/locales/en/resources.json
@@ -154,7 +154,7 @@
     "qwen": {
       "name": "Qwen3-ASR",
       "builtinRuntime": "The runtime is bundled with the app (shared with FunASR) — no download needed.",
-      "desc": "Alibaba Qwen3-ASR (0.6B) running locally on the sherpa-onnx runtime (shared with FunASR). Open-source, multilingual, CPU-friendly — no GPU or Python required. Segment-level timestamps come from VAD.",
+      "desc": "Alibaba Qwen3-ASR (0.6B / 1.7B) running locally on the sherpa-onnx runtime (shared with FunASR). Open-source and multilingual — no GPU or Python required. Segment-level timestamps come from VAD.",
       "scenario": "Best for: multilingual local transcription on CPU, Apache-2.0",
       "notInstalled": "Not installed",
       "needsModels": "Models needed",
@@ -178,14 +178,14 @@
       "checkFailed": "Failed to check for updates. Please try again later.",
       "anotherDownload": "Another download is in progress. Please wait for it to finish.",
       "advanced": "Advanced settings",
-      "providerNote": "Current scope: CPU only (0.6B). GPU support is planned for a future release.",
+      "providerNote": "Current scope: CPU inference. 0.6B is lighter; 1.7B offers higher accuracy but needs more memory and time. GPU support is planned for a future release.",
       "numThreads": "Inference threads",
       "numThreadsHint": "Threads used for CPU inference — higher is faster but uses more CPU",
       "modelsTitle": "Models",
       "needModelsHint": "Download to enable",
       "modelDownload": "Download",
       "modelDelete": "Delete",
-      "modelDownloadConfirm": "Qwen3-ASR (0.6B) is about {{size}}. It runs on CPU but is not real-time. Continue?",
+      "modelDownloadConfirm": "The Qwen3-ASR model is about {{size}}. It runs on CPU but is not real-time. Continue?",
       "modelSources": {
         "modelscope": "ModelScope (CN)",
         "ghproxy": "GitHub Mirror (China)",
@@ -200,6 +200,10 @@
         "qwen3-asr-0.6b": {
           "name": "Qwen3-ASR 0.6B (int8, ~0.95GB)",
           "desc": "Multilingual local ASR; int8 quantized, CPU-friendly. Segment-level timestamps via VAD."
+        },
+        "qwen3-asr-1.7b": {
+          "name": "Qwen3-ASR 1.7B (int8, ~2.4GB)",
+          "desc": "Larger model for higher recognition accuracy; needs more memory and is slower on CPU. Currently downloaded from ModelScope."
         }
       }
     },

--- a/renderer/public/locales/zh/resources.json
+++ b/renderer/public/locales/zh/resources.json
@@ -154,7 +154,7 @@
     "qwen": {
       "name": "Qwen3-ASR",
       "builtinRuntime": "运行库已随应用内置（与 FunASR 共用），无需单独下载。",
-      "desc": "阿里 Qwen3-ASR（0.6B）本地引擎，基于 sherpa-onnx 运行（与 FunASR 共用运行库）：开源、多语种、CPU 友好，无需显卡或 Python。段级时间戳来自 VAD 切分。",
+      "desc": "阿里 Qwen3-ASR（0.6B / 1.7B）本地引擎，基于 sherpa-onnx 运行（与 FunASR 共用运行库）：开源、多语种，无需显卡或 Python。段级时间戳来自 VAD 切分。",
       "scenario": "适合：CPU 本地多语种转写，Apache-2.0 开源",
       "notInstalled": "未安装",
       "needsModels": "需下载模型",
@@ -178,14 +178,14 @@
       "checkFailed": "检查更新失败，请稍后重试。",
       "anotherDownload": "已有下载任务进行中，请等待完成后再试。",
       "advanced": "高级设置",
-      "providerNote": "当前范围：仅 CPU（0.6B）。GPU 支持计划在后续版本提供。",
+      "providerNote": "当前范围：CPU 推理。0.6B 更轻量，1.7B 精度更高但需要更多内存和时间；GPU 支持计划在后续版本提供。",
       "numThreads": "推理线程数",
       "numThreadsHint": "CPU 推理使用的线程数，越大越快但占用更多 CPU",
       "modelsTitle": "模型",
       "needModelsHint": "下载后才能使用",
       "modelDownload": "下载",
       "modelDelete": "删除",
-      "modelDownloadConfirm": "Qwen3-ASR（0.6B）约 {{size}}。可在 CPU 上运行，但非实时。是否继续？",
+      "modelDownloadConfirm": "Qwen3-ASR 模型约 {{size}}。可在 CPU 上运行，但非实时。是否继续？",
       "modelSources": {
         "modelscope": "ModelScope（国内）",
         "ghproxy": "github 国内加速",
@@ -200,6 +200,10 @@
         "qwen3-asr-0.6b": {
           "name": "Qwen3-ASR 0.6B（int8，约 0.95GB）",
           "desc": "多语种本地识别；int8 量化，CPU 友好。段级时间戳来自 VAD。"
+        },
+        "qwen3-asr-1.7b": {
+          "name": "Qwen3-ASR 1.7B（int8，约 2.4GB）",
+          "desc": "更大模型，识别精度更高；需要更多内存，CPU 推理速度也更慢。当前通过 ModelScope 下载。"
         }
       }
     },

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -53,6 +53,7 @@ import {
   toFriendlyFfmpegError,
 } from '../main/helpers/ffmpegErrorUtils';
 import fs from 'fs';
+import http from 'http';
 import os from 'os';
 import nodePath from 'path';
 import {
@@ -66,6 +67,9 @@ import {
   getQwenModelIds,
   getQwenSourceOrder,
   getQwenSupportedSources,
+  getQwenRequiredFileExpectations,
+  getQwenModelScopeFileUrl,
+  getQwenModelScopeTreeUrl,
   resolveQwenSelection,
 } from '../main/helpers/qwenModelCatalog';
 import { FIRERED_MODELS } from '../main/helpers/fireRedModelCatalog';
@@ -74,6 +78,7 @@ import {
   CT2_REQUIRED_CONFIG_ARRAYS,
   inspectCt2SnapshotRoot,
   validateModelLayout,
+  validateModelLayoutWithSizes,
   validateCt2ModelSnapshot,
   resolveOverridePath,
   resolveBundledVadPath,
@@ -84,6 +89,7 @@ import {
   prepareDownloadTarget,
   validateDownloadResponse,
 } from '../main/helpers/download/resumeIntegrity';
+import { fetchJson } from '../main/helpers/download/fetchJson';
 import {
   buildVadConfig,
   buildRecognizerConfig,
@@ -1321,6 +1327,21 @@ eq(
     true,
     'import: present nested file -> ok',
   );
+  fs.writeFileSync(nodePath.join(tmp, 'empty.onnx'), '');
+  fs.mkdirSync(nodePath.join(tmp, 'directory.onnx'));
+  eq(
+    validateModelLayout(tmp, ['empty.onnx', 'directory.onnx']).missing,
+    ['empty.onnx', 'directory.onnx'],
+    'import: empty files and directories are rejected',
+  );
+  eq(
+    validateModelLayoutWithSizes(tmp, [
+      { path: 'encoder.int8.onnx', size: 1 },
+      { path: 'decoder.int8.onnx', size: 2 },
+    ]).missing,
+    ['decoder.int8.onnx'],
+    'import: exact-size validation reports wrong-sized files',
+  );
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 
@@ -1505,6 +1526,47 @@ eq(
   'import: qwen model sizes share the same runtime layout',
 );
 eq(
+  QWEN_MODELS['qwen3-asr-1.7b'].requiredFiles.includes(
+    'tokenizer/tokenizer_config.json',
+  ),
+  true,
+  'import: qwen runtime marker includes required tokenizer_config.json',
+);
+{
+  const qwen06Sizes = Object.fromEntries(
+    getQwenRequiredFileExpectations('qwen3-asr-0.6b').map((file) => [
+      file.path,
+      file.size,
+    ]),
+  );
+  const qwen17Sizes = Object.fromEntries(
+    getQwenRequiredFileExpectations('qwen3-asr-1.7b').map((file) => [
+      file.path,
+      file.size,
+    ]),
+  );
+  eq(
+    qwen06Sizes['decoder.int8.onnx'],
+    755_914_231,
+    'qwen catalog: 0.6B decoder has pinned official size',
+  );
+  eq(
+    qwen17Sizes['decoder.int8.onnx'],
+    2_037_458_645,
+    'qwen catalog: 1.7B decoder has pinned official size',
+  );
+  eq(
+    qwen17Sizes['decoder.int8.onnx'] === qwen06Sizes['decoder.int8.onnx'],
+    false,
+    'qwen import: 0.6B decoder cannot satisfy the 1.7B slot identity',
+  );
+  eq(
+    qwen17Sizes['tokenizer/tokenizer_config.json'],
+    12_487,
+    'qwen catalog: tokenizer_config has pinned official size',
+  );
+}
+eq(
   QWEN_MODELS['qwen3-asr-1.7b'].modelScopeFiles
     .map((file) => file.remote)
     .slice(0, 3),
@@ -1514,6 +1576,29 @@ eq(
     'model_1.7B/decoder.int8.onnx',
   ],
   'qwen catalog: 1.7B points at the official int8 ModelScope layout',
+);
+eq(
+  QWEN_MODELS['qwen3-asr-1.7b'].modelScopeFiles.reduce(
+    (total, file) => total + file.size,
+    0,
+  ),
+  2_404_230_105,
+  'qwen catalog: 1.7B pinned files total 2.404 GB',
+);
+eq(
+  getQwenModelScopeFileUrl(
+    QWEN_MODELS['qwen3-asr-1.7b'],
+    'model_1.7B/decoder.int8.onnx',
+  ).includes('/resolve/master/'),
+  false,
+  'qwen catalog: file downloads use an immutable revision',
+);
+eq(
+  getQwenModelScopeTreeUrl(QWEN_MODELS['qwen3-asr-1.7b']).includes(
+    'Revision=master',
+  ),
+  false,
+  'qwen catalog: tree metadata uses the same immutable revision',
 );
 eq(
   getQwenModelIds(),
@@ -5901,6 +5986,52 @@ function sleepMs(ms: number): Promise<void> {
 }
 
 async function runAsyncConcurrencyTests(): Promise<void> {
+  // 可取消 JSON 请求：重定向后的慢文件树请求仍必须响应同一个 AbortSignal。
+  {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/redirect') {
+        res.statusCode = 302;
+        res.setHeader('Location', '/slow-tree');
+        res.end();
+      }
+      // /slow-tree 故意不结束响应；测试必须依赖 abort 退出。
+    });
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => reject(error);
+      server.once('error', onError);
+      server.listen(0, '127.0.0.1', () => {
+        server.removeListener('error', onError);
+        resolve();
+      });
+    });
+    try {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('test server did not expose a TCP port');
+      }
+      const abort = new AbortController();
+      let fetchError: unknown = null;
+      const pending = fetchJson(`http://127.0.0.1:${address.port}/redirect`, {
+        signal: abort.signal,
+        timeoutMs: 2_000,
+        cancelMessage: 'Download cancelled',
+      }).catch((error) => {
+        fetchError = error;
+        return null;
+      });
+      await sleepMs(20);
+      abort.abort();
+      await pending;
+      eq(
+        fetchError instanceof Error ? fetchError.message : String(fetchError),
+        'Download cancelled',
+        'qwen download: abort survives JSON redirect and cancels tree fetch',
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
   // 非受限引擎不排队：未释放前重复获取也立即放行
   {
     const r1 = await acquireTranscribeSlot('builtin');

--- a/scripts/test-engine-units.ts
+++ b/scripts/test-engine-units.ts
@@ -60,7 +60,14 @@ import {
   resolveFunasrAsrSelection,
   FUNASR_MODELS,
 } from '../main/helpers/funasrModelCatalog';
-import { QWEN_MODELS } from '../main/helpers/qwenModelCatalog';
+import {
+  QWEN_MODELS,
+  getQwenArchiveUrl,
+  getQwenModelIds,
+  getQwenSourceOrder,
+  getQwenSupportedSources,
+  resolveQwenSelection,
+} from '../main/helpers/qwenModelCatalog';
 import { FIRERED_MODELS } from '../main/helpers/fireRedModelCatalog';
 import {
   CT2_REQUIRED_FILES,
@@ -989,17 +996,17 @@ const qwenReady = {
   transcriptionEngine: 'qwen' as const,
   qwenEngineInstalled: true,
   qwenVadInstalled: true,
-  qwenModelsInstalled: ['qwen3-asr-0.6b'],
+  qwenModelsInstalled: ['qwen3-asr-0.6b', 'qwen3-asr-1.7b'],
 };
 eq(
   getSelectableModelsForEngine(qwenReady),
-  ['qwen3-asr-0.6b'],
-  'engineModels: qwen selectable = installed qwen models',
+  ['qwen3-asr-0.6b', 'qwen3-asr-1.7b'],
+  'engineModels: qwen selectable includes both installed model sizes',
 );
 eq(
   getInstalledModelsForEngine(qwenReady),
-  ['qwen3-asr-0.6b'],
-  'engineModels: qwen installed = installed qwen models',
+  ['qwen3-asr-0.6b', 'qwen3-asr-1.7b'],
+  'engineModels: qwen installed includes both installed model sizes',
 );
 eq(
   hasModelsForEngine(qwenReady),
@@ -1491,6 +1498,57 @@ eq(
   QWEN_MODELS['qwen3-asr-0.6b'].requiredFiles.includes('tokenizer/vocab.json'),
   true,
   'import: qwen requiredFiles include nested tokenizer file',
+);
+eq(
+  QWEN_MODELS['qwen3-asr-1.7b'].requiredFiles,
+  QWEN_MODELS['qwen3-asr-0.6b'].requiredFiles,
+  'import: qwen model sizes share the same runtime layout',
+);
+eq(
+  QWEN_MODELS['qwen3-asr-1.7b'].modelScopeFiles
+    .map((file) => file.remote)
+    .slice(0, 3),
+  [
+    'model_1.7B/conv_frontend.onnx',
+    'model_1.7B/encoder.int8.onnx',
+    'model_1.7B/decoder.int8.onnx',
+  ],
+  'qwen catalog: 1.7B points at the official int8 ModelScope layout',
+);
+eq(
+  getQwenModelIds(),
+  ['qwen3-asr-0.6b', 'qwen3-asr-1.7b'],
+  'qwen catalog: exposes both 0.6B and 1.7B',
+);
+eq(
+  getQwenSupportedSources('qwen3-asr-0.6b'),
+  ['modelscope', 'ghproxy', 'github'],
+  'qwen catalog: 0.6B retains all download sources',
+);
+eq(
+  getQwenSupportedSources('qwen3-asr-1.7b'),
+  ['modelscope'],
+  'qwen catalog: 1.7B only exposes its available ModelScope source',
+);
+eq(
+  getQwenArchiveUrl(QWEN_MODELS['qwen3-asr-1.7b'], 'github'),
+  null,
+  'qwen catalog: 1.7B never fabricates a missing GitHub archive URL',
+);
+eq(
+  getQwenSourceOrder('github', getQwenSupportedSources('qwen3-asr-1.7b')),
+  ['modelscope'],
+  'qwen catalog: unsupported 1.7B source safely falls back to ModelScope',
+);
+eq(
+  resolveQwenSelection('qwen3-asr-1.7b', ['qwen3-asr-0.6b', 'qwen3-asr-1.7b']),
+  { id: 'qwen3-asr-1.7b' },
+  'qwen selection: requested installed 1.7B reaches the runtime',
+);
+eq(
+  resolveQwenSelection('qwen3-asr-1.7b', ['qwen3-asr-0.6b']),
+  { id: 'qwen3-asr-0.6b' },
+  'qwen selection: missing 1.7B falls back to an installed model',
 );
 eq(
   FIRERED_MODELS['fire-red-asr-large-zh-en'].requiredFiles,


### PR DESCRIPTION
## 变更内容

- 在保留 Qwen3-ASR 0.6B 的同时新增 Qwen3-ASR 1.7B，可在资源页分别下载、导入、删除和选择
- 将 Qwen 模型定义扩展为多模型 catalog，下载器、安装状态、任务模型选择和预热/转写统一按模型 id 解析
- 接入官方 sherpa-onnx 指向的 ModelScope int8 文件布局，下载并校验 conv frontend、encoder、decoder 与 tokenizer 共 9 个文件
- 固定不可变 ModelScope revision，并为 0.6B/1.7B 分别记录官方精确文件大小；安装与导入会拒绝空文件、缺失 `tokenizer_config.json`、截断文件及把 0.6B 冒充为 1.7B 的同名布局
- 下载取消使用单次会话隔离，覆盖文件树请求、重定向、并行/单连接流；旧任务不能复用新 signal 或清理新任务状态
- 资源页改为多模型列表，分别展示体积与适用场景，并补齐下载进度、取消、来源限制和删除确认
- 补齐中英文界面、三语 README、引擎文档和模型完整性/取消竞态回归测试

## 下载与兼容说明

- 1.7B 模型约 2.4 GB；默认模型仍为更轻量的 0.6B，历史任务与已有安装保持兼容
- sherpa-onnx 当前没有发布 1.7B 的 GitHub release 整包，因此 1.7B 只展示真实可用的 ModelScope 来源，不生成无效下载链接
- 0.6B 继续支持 ModelScope、GitHub 直连和 GitHub 代理回退
- sherpa-onnx 运行所需的 `vocab.json`、`merges.txt`、`tokenizer_config.json` 均纳入安装完整性标记

## 验证

- `npm run test:engines`：746/746
- `npm run check:i18n`
- `npm run build`：Renderer + Main production build 通过
- 通过官方 ModelScope revision 核对 0.6B/1.7B 九文件路径与精确大小；1.7B 总计 2,404,230,105 字节
- 取消、302 重定向、模型槽身份和空/错尺寸文件回归测试
- Prettier、`git diff --check`

## 未覆盖的手动验证

- 未在本地完整下载约 2.4 GB 模型执行真实音频转写；运行链路沿用已经工作的 Qwen sherpa-onnx worker，并由固定文件布局、精确大小和自动化测试覆盖

Closes #361