### PR TITLE
docs: fix broken star history chart in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,4 +372,4 @@ yarn dev
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=buxuku/SmartSub&type=Date)](https://star-history.com/#buxuku/SmartSub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=buxuku/SmartSub&type=Date)](https://star-history.dera.page/#buxuku/SmartSub&type=Date)

--- a/README_EN.md
+++ b/README_EN.md
@@ -372,4 +372,4 @@ MIT — see the [LICENSE](LICENSE) file for details.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=buxuku/SmartSub&type=Date)](https://star-history.com/#buxuku/SmartSub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=buxuku/SmartSub&type=Date)](https://star-history.dera.page/#buxuku/SmartSub&type=Date)

--- a/README_JA.md
+++ b/README_JA.md
@@ -371,4 +371,4 @@ MIT ライセンス。詳細は [LICENSE](LICENSE) ファイルを参照して�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=buxuku/SmartSub&type=Date)](https://star-history.com/#buxuku/SmartSub&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=buxuku/SmartSub&type=Date)](https://star-history.dera.page/#buxuku/SmartSub&type=Date)


### PR DESCRIPTION
The star history chart at the bottom of the README files is currently broken and no longer renders. This is caused by the GitHub stargazer API restrictions that the chart relies on. Please take a look and merge this fix so the chart is restored. The change only updates the chart image and link in the Chinese, English, and Japanese README files.