### PR TITLE
fix(tts): 修复 Kokoro 英文音色的数字朗读

### DIFF
--- a/main/helpers/dubbing/dubbingProcessor.ts
+++ b/main/helpers/dubbing/dubbingProcessor.ts
@@ -21,6 +21,7 @@ import {
   type SubtitleCue,
 } from '../subtitleFormats';
 import { normalizeDubbingSpeechText } from './textNormalization';
+import { resolveTtsModelRequestForVoice } from './ttsLanguageRules';
 import {
   computeSlots,
   estimateDurationMs,
@@ -616,7 +617,7 @@ function buildEngineAdapter(
       synthesize: async (text, voiceId, speed, outWavPath, signal) =>
         runSynthesize(
           {
-            model,
+            model: resolveTtsModelRequestForVoice(spec, model, voiceId),
             text,
             sid: resolveTtsVoiceSid(spec, voiceId),
             speed,

--- a/main/helpers/dubbing/ttsLanguageRules.ts
+++ b/main/helpers/dubbing/ttsLanguageRules.ts
@@ -1,0 +1,54 @@
+/**
+ * 本地多语 TTS 的音色级前端规则选择。
+ *
+ * sherpa-onnx 的 ruleFsts 属于 OfflineTts 模型级配置，不会随 sid 切换，因此
+ * Kokoro 模型包里的中文 phone/date/number FST 也会改写英文音色的数字（例如
+ * `1` 被读成 yi）。英文 sid 应跳过这些中文规则，交给 Kokoro 的 espeak-ng
+ * 英文前端处理；中文 sid 继续保留原规则。
+ */
+
+interface VoiceLanguageProfile {
+  id: string;
+  lang: 'zh' | 'en';
+}
+
+interface VoiceAwareModelSpec {
+  id: string;
+  defaultVoiceId: string;
+  voices: VoiceLanguageProfile[];
+}
+
+interface RuleFstModelRequest {
+  ruleFsts?: string;
+}
+
+const KOKORO_MULTI_LANG_MODEL_ID = 'kokoro-multi-lang-v1_1';
+
+function resolveVoice(
+  spec: VoiceAwareModelSpec,
+  voiceId: string | undefined,
+): VoiceLanguageProfile | undefined {
+  return (
+    spec.voices.find((voice) => voice.id === voiceId) ??
+    spec.voices.find((voice) => voice.id === spec.defaultVoiceId)
+  );
+}
+
+export function resolveTtsModelRequestForVoice<T extends RuleFstModelRequest>(
+  spec: VoiceAwareModelSpec,
+  model: T,
+  voiceId?: string,
+): T {
+  const voice = resolveVoice(spec, voiceId);
+  if (
+    spec.id !== KOKORO_MULTI_LANG_MODEL_ID ||
+    voice?.lang !== 'en' ||
+    !model.ruleFsts
+  ) {
+    return model;
+  }
+
+  const englishModel = { ...model };
+  delete englishModel.ruleFsts;
+  return englishModel;
+}

--- a/scripts/dubbing/test-dubbing-units.ts
+++ b/scripts/dubbing/test-dubbing-units.ts
@@ -86,6 +86,7 @@ import {
   resolveTtsVoiceLabel,
 } from '../../types/ttsProvider';
 import { loadDubbingSpeakerMetadata } from '../../main/helpers/dubbing/speakerMetadata';
+import { resolveTtsModelRequestForVoice } from '../../main/helpers/dubbing/ttsLanguageRules';
 
 let passed = 0;
 let failed = 0;
@@ -108,6 +109,63 @@ function ok(cond: boolean, name: string): void {
     failed++;
     console.error(`✗ ${name}`);
   }
+}
+
+// ── Kokoro 多语音色：英文 sid 不加载中文数字 FST（issue #426）──────────────
+
+{
+  const kokoro = {
+    id: 'kokoro-multi-lang-v1_1',
+    defaultVoiceId: '10',
+    voices: [
+      { id: '0', lang: 'en' as const },
+      { id: '1', lang: 'en' as const },
+      { id: '2', lang: 'en' as const },
+      { id: '10', lang: 'zh' as const },
+    ],
+  };
+  const baseModel = {
+    modelType: 'kokoro',
+    ruleFsts:
+      '/models/kokoro/phone-zh.fst,/models/kokoro/date-zh.fst,/models/kokoro/number-zh.fst',
+  };
+
+  for (const voiceId of ['0', '1', '2']) {
+    const englishModel = resolveTtsModelRequestForVoice(
+      kokoro,
+      baseModel,
+      voiceId,
+    );
+    eq(
+      englishModel.ruleFsts,
+      undefined,
+      `kokoro: 英文音色 ${voiceId} 不加载中文数字 FST`,
+    );
+  }
+
+  eq(
+    resolveTtsModelRequestForVoice(kokoro, baseModel, '10').ruleFsts,
+    baseModel.ruleFsts,
+    'kokoro: 中文音色继续加载中文数字 FST',
+  );
+  eq(
+    resolveTtsModelRequestForVoice(kokoro, baseModel, 'missing').ruleFsts,
+    baseModel.ruleFsts,
+    'kokoro: 未知音色按默认中文音色回退',
+  );
+  ok(Boolean(baseModel.ruleFsts), 'kokoro: 语言适配不修改基础模型请求');
+
+  const vits = {
+    id: 'vits-zh-aishell3',
+    defaultVoiceId: '0',
+    voices: [{ id: '0', lang: 'zh' as const }],
+  };
+  const vitsModel = { modelType: 'vits', ruleFsts: '/models/vits/number.fst' };
+  eq(
+    resolveTtsModelRequestForVoice(vits, vitsModel, '0').ruleFsts,
+    vitsModel.ruleFsts,
+    'vits: 非 Kokoro 模型不受影响',
+  );
 }
 
 function cue(


### PR DESCRIPTION
## 变更内容

- 为 Kokoro 三个英文音色（sid 0–2）跳过模型包内面向中文的电话、日期和数字 FST 规则，改由 Kokoro 的 espeak-ng 英文前端处理数字
- 中文音色继续使用原有 FST；未知音色回退和 VITS 路径行为保持不变
- 抽取 TTS 语言规则决策，补齐三个英文音色、中文音色、未知音色和 VITS 的回归测试

## 原因与兼容说明

- sherpa-onnx 的 `ruleFsts` 配置作用于整个 `OfflineTts` 模型，而不是单个 sid；此前 SmartSub 会为全部 Kokoro 音色加载中文规则，导致英文音色可能把 `1` 读成 “yi”，并把 `90%` 错读为类似 “cent” 的内容
- 本次只改变 Kokoro 英文音色 sid 0–2 的前端规则；中文音色仍按原方式处理电话、日期和数字
- 未知 sid 继续沿用原有规则作为保守回退；VITS 引擎不受影响

## 验证

- `npm run test:dubbing`：179/179
- Prettier 检查通过
- 使用真实 Kokoro v1.1 对 sid 0、1、2 执行 `1. The project is 90% complete.` A/B 验证：
  - 修复前：tiny.en 将 `1` 识别为 `Lee` / `E` / `Yee`，并将 `90%` 识别为 `CO sent` / `cent` 等错误结果
  - 修复后：三个英文音色均可识别为 `One` / `1` 和 `90% complete`

## 尚未覆盖

- #426 中“新增更多外语模型”的诉求不在本 PR 范围内，后续仍需单独实现
- 仓库级 `npx tsc --noEmit` 仍受主线已有的文档依赖、路径别名和旧类型错误影响；本次改动已由专项测试与格式检查覆盖

部分解决 #426