### PR TITLE
fix: 更新通义千问百炼控制台链接

### DIFF
--- a/renderer/public/locales/en/translateControl.json
+++ b/renderer/public/locales/en/translateControl.json
@@ -79,7 +79,7 @@
   "siliconflowApiKeyTips": "SiliconFlow API Key — create in <a href='https://cloud.siliconflow.cn/account/ak' style='color: blue'>API Key Management</a>.",
   "qwenApiUrlTips": "Qwen OpenAI-compatible endpoint — DashScope default URL, usually no change needed.",
   "qwenMtApiUrlTips": "Dedicated Qwen-MT OpenAI-compatible endpoint. Each request sends one user message and specifies languages and terms through translation_options.",
-  "qwenApiKeyTips": "DashScope API Key — get one from the <a href='https://dashscope.console.aliyun.com/apiKey' style='color: blue'>Bailian Console</a>.",
+  "qwenApiKeyTips": "DashScope API Key — get one from the <a href='https://bailian.console.aliyun.com/?tab=model#/api-key' style='color: blue'>Bailian Console</a>.",
   "openaiApiUrlTips": "OpenAI-compatible API base URL, usually ending in /v1, e.g. https://api.openai.com/v1. Do not paste a model detail page or /chat/completions endpoint — SmartSub appends the chat path automatically.",
   "openaiModelNameTips": "Enter the exact model id from your provider, e.g. hunyuan-3.0-preview. If the test fails with a response_format error, set Structured Output to Disabled.",
   "openaiApiKeyTips": "OpenAI API Key — create at the <a href='https://platform.openai.com/api-keys' style='color: blue'>OpenAI Platform</a>.",

--- a/renderer/public/locales/zh/translateControl.json
+++ b/renderer/public/locales/zh/translateControl.json
@@ -81,7 +81,7 @@
   "siliconflowApiKeyTips": "SiliconFlow API Key，可在 <a href='https://cloud.siliconflow.cn/account/ak' style='color: blue'>API 密钥管理</a> 创建。",
   "qwenApiUrlTips": "通义千问 OpenAI 兼容端点，默认为 DashScope 地址，一般无需修改。",
   "qwenMtApiUrlTips": "Qwen-MT 专用 OpenAI 兼容端点，默认为 DashScope 地址。请求仅发送一条用户消息，并通过 translation_options 指定语种与术语。",
-  "qwenApiKeyTips": "DashScope API Key，可在 <a href='https://dashscope.console.aliyun.com/apiKey' style='color: blue'>百炼控制台</a> 获取。",
+  "qwenApiKeyTips": "DashScope API Key，可在 <a href='https://bailian.console.aliyun.com/?tab=model#/api-key' style='color: blue'>百炼控制台</a> 获取。",
   "openaiApiUrlTips": "OpenAI 兼容 API 的基础地址，通常以 /v1 结尾，如 https://api.openai.com/v1。请勿粘贴模型详情页或 /chat/completions 接口，SmartSub 会自动拼接聊天接口路径。",
   "openaiModelNameTips": "填写服务商提供的准确模型 ID，例如 hunyuan-3.0-preview。如果测试提示 response_format 不支持，请将「结构化输出」改为 Disabled。",
   "openaiApiKeyTips": "OpenAI API Key，可在 <a href='https://platform.openai.com/api-keys' style='color: blue'>OpenAI 平台</a> 创建。",


### PR DESCRIPTION
## 修改内容

- 将通义千问与 Qwen-MT 配置提示中的旧 DashScope API Key 链接更新为当前百炼控制台入口
- 同步更新中文和英文文案

## 验证

- `npm run check:i18n`
- 中英文本地化 JSON 解析及链接精确断言
- `git diff --check`

Fixes #460